### PR TITLE
debt: Upgraded to [nanoid@v1.18.1](https://github.com/sixafter/nanoid/releases/tag/v1.18.1)

### DIFF
--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -1,0 +1,86 @@
+# Copyright (c) 2024 Six After, Inc
+#
+# This source code is licensed under the Apache 2.0 License found in the
+# LICENSE file in the root directory of this source tree.
+
+# Ref: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions
+name: "CodeQL Analysis"
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+
+  push:
+    branches:
+      - main
+
+    paths-ignore:
+      - 'CHANGELOG/**'
+      - 'CODEOWNERS'
+      - 'docs/**'
+      - 'LICENSE'
+      - '**/*.md'
+
+  schedule:
+    # * * * * * <command to execute>
+    # | | | | |
+    # | | | | day of the week (0–6) (Sunday to Saturday;
+    # | | | month (1–12)             7 is also Sunday on some systems)
+    # | | day of the month (1–31)
+    # | hour (0–23)
+    # minute (0–59)
+    - cron: '0 0 * * 3'
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        include:
+          - language: go
+
+    permissions:
+      security-events: write
+
+    steps:
+      - name: Preamble
+        run: |
+          whoami
+          echo github ref $GITHUB_REF
+          echo workflow $GITHUB_WORKFLOW
+          echo home $HOME
+          echo event name $GITHUB_EVENT_NAME
+          echo workspace $GITHUB_WORKSPACE
+
+          df -h
+
+          sudo DEBIAN_FRONTEND=noninteractive apt-get update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y software-properties-common ca-certificates gnupg-agent curl build-essential make
+
+      # Ref: https://github.com/actions/checkout
+      - name: Checkout Source
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Ref: https://github.com/actions/setup-go
+      - name: Install Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      # Ref: https://github.com/github/codeql-action
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v3
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3

--- a/CHANGELOG/CHANGELOG-1.x.md
+++ b/CHANGELOG/CHANGELOG-1.x.md
@@ -5,6 +5,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+Date format: `YYYY-MM-DD`
+
 ---
 ## [Unreleased]
 
@@ -16,7 +18,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 ---
-## [1.1.0] - 2024-OCT-24
+## [1.2.0] - 2024-11-15
+
+### Added
+### Changed
+- **DEBT:** Added missing license header to the CodeQL analysis configuration file.
+- **DEBT:** Refactored CHANGELOG date format to `YYYY-MM-DD`.
+- **DEBT:** Upgraded to [sixafter/nanoid@v1.17.3](https://github.com/sixafter/nanoid/releases/tag/v1.18.1).
+
+### Deprecated
+### Removed
+### Fixed
+### Security
+
+---
+## [1.1.0] - 2024-11-14
+
+### Added
+### Changed
+- **DEBT:** Upgraded to [sixafter/nanoid@v1.17.3](https://github.com/sixafter/nanoid/releases/tag/v1.17.3).
+
+### Deprecated
+### Removed
+### Fixed
+### Security
+
+---
+## [1.1.0] - 2024-11-14
 
 ### Added
 ### Changed
@@ -27,7 +55,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 ---
-## [1.0.1] - 2024-OCT-24
+## [1.0.1] - 2024-11-14
 
 ### Added
 - **FEATURE:** Added support for Homebrew.
@@ -38,7 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 ---
-## [1.0.0] - 2024-OCT-24
+## [1.0.0] - 2024-11-13
 
 ### Added
 - **FEATURE:** Initial commit.
@@ -48,7 +76,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 ### Security
 
-[Unreleased]: https://github.com/sixafter/nanoid-cli/compare/v1.1.0..HEAD
+[Unreleased]: https://github.com/sixafter/nanoid-cli/compare/v1.2.0..HEAD
+[1.2.0]: https://github.com/sixafter/nanoid-cli/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/sixafter/nanoid-cli/compare/v1.0.1...v1.1.0
 [1.0.1]: https://github.com/sixafter/nanoid-cli/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/sixafter/nanoid-cli/compare/a6a1eb74b61e518fd0216a17dfe5c9b4c432e6e8...v1.0.0

--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ GO_WORK_FILE := ./go.work
 export BINARY_NAME=out/nanoid
 
 .PHONY: all
-all: clean test
+all: clean build test
 
 .PHONY: build
 build: ## Build the binary executable.

--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -91,7 +91,7 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("error generating Nano ID: %w", err)
 		}
 
-		_, err = writer.WriteString(id + "\n")
+		_, err = writer.WriteString(id.String() + "\n")
 		if err != nil {
 			return fmt.Errorf("error writing Nano ID: %w", err)
 		}

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.23
 
 require (
 	github.com/blang/semver/v4 v4.0.0
-	github.com/sixafter/nanoid v1.18.0
+	github.com/sixafter/nanoid v1.18.1
 	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.9.0
 )

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.23
 
 require (
 	github.com/blang/semver/v4 v4.0.0
-	github.com/sixafter/nanoid v1.17.3
+	github.com/sixafter/nanoid v1.18.0
 	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.9.0
 )

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLf
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/sixafter/nanoid v1.18.0 h1:T8AZHGvdsDGK3HqaNtvm9tEjauAX+Iox7lS2PSn1O98=
-github.com/sixafter/nanoid v1.18.0/go.mod h1:dQjvP7lwL/M43aOsHeN09O5+5/2SKzatkjvJDJBTeVE=
+github.com/sixafter/nanoid v1.18.1 h1:qIO2B3JMdbgedLW1+IbTABAr4i7h3HY/YnyuvENQgq0=
+github.com/sixafter/nanoid v1.18.1/go.mod h1:dQjvP7lwL/M43aOsHeN09O5+5/2SKzatkjvJDJBTeVE=
 github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
 github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLf
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/sixafter/nanoid v1.17.3 h1:0xDxzu01jqeQM2wZP92UIyHia7h+Nn5UbIMrCGlxAoA=
-github.com/sixafter/nanoid v1.17.3/go.mod h1:dQjvP7lwL/M43aOsHeN09O5+5/2SKzatkjvJDJBTeVE=
+github.com/sixafter/nanoid v1.18.0 h1:T8AZHGvdsDGK3HqaNtvm9tEjauAX+Iox7lS2PSn1O98=
+github.com/sixafter/nanoid v1.18.0/go.mod h1:dQjvP7lwL/M43aOsHeN09O5+5/2SKzatkjvJDJBTeVE=
 github.com/spf13/cobra v1.8.1 h1:e5/vxKd/rZsfSJMUX1agtjeTDf+qv1/JdBF8gg5k9ZM=
 github.com/spf13/cobra v1.8.1/go.mod h1:wHxEcudfqmLYa8iTfL+OuZPbBZkmvliBWKIezN3kD9Y=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=

--- a/vendor/github.com/sixafter/nanoid/.goreleaser.yaml
+++ b/vendor/github.com/sixafter/nanoid/.goreleaser.yaml
@@ -84,7 +84,7 @@ sboms:
 release:
   name_template: 'v{{ .Version }}'
   footer: |
-    **Full Changelog**: [https://github.com/sixafter/nanoid/tree/main/CHANGELOG/CHANGELOG-1.x](https://github.com/sixafter/nanoid/tree/main/CHANGELOG/CHANGELOG-1.x.md)
+    **Full Changelog**: [CHANGELOG](https://github.com/sixafter/nanoid/tree/main/CHANGELOG/CHANGELOG-1.x.md)
         
     ## Where to go next?
     

--- a/vendor/github.com/sixafter/nanoid/Makefile
+++ b/vendor/github.com/sixafter/nanoid/Makefile
@@ -36,7 +36,7 @@ bench: ## Execute benchmark tests
 
 .PHONY: clean
 clean: ## Remove previous build
-	$(GO_CLEAN)
+	$(GO_CLEAN) ./...
 
 .PHONY: cover
 cover: ## Generate global code coverage report

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -10,7 +10,7 @@ github.com/inconshreveable/mousetrap
 # github.com/pmezard/go-difflib v1.0.0
 ## explicit
 github.com/pmezard/go-difflib/difflib
-# github.com/sixafter/nanoid v1.17.3
+# github.com/sixafter/nanoid v1.18.0
 ## explicit; go 1.23
 github.com/sixafter/nanoid
 github.com/sixafter/nanoid/x/crypto/prng

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -10,7 +10,7 @@ github.com/inconshreveable/mousetrap
 # github.com/pmezard/go-difflib v1.0.0
 ## explicit
 github.com/pmezard/go-difflib/difflib
-# github.com/sixafter/nanoid v1.18.0
+# github.com/sixafter/nanoid v1.18.1
 ## explicit; go 1.23
 github.com/sixafter/nanoid
 github.com/sixafter/nanoid/x/crypto/prng


### PR DESCRIPTION
- **DEBT:** Added missing license header to the CodeQL analysis configuration file.
- **DEBT:** Refactored CHANGELOG date format to `YYYY-MM-DD`.
