### PR TITLE
debt: Upgraded dependencies

### DIFF
--- a/CHANGELOG/CHANGELOG-1.x.md
+++ b/CHANGELOG/CHANGELOG-1.x.md
@@ -19,6 +19,20 @@ Date format: `YYYY-MM-DD`
 
 ---
 
+## [1.35.0] - 2025-09-10
+
+### Added
+### Changed
+- **debt:** Upgraded dependencies to their latest stable versions.
+- **debt:** Upgraded to [sixafter/nanoid@v1.50.0](https://github.com/sixafter/nanoid/releases/tag/v1.50.0).
+
+### Deprecated
+### Removed
+### Fixed
+### Security
+
+---
+
 ## [1.34.0] - 2025-09-09
 
 ### Added
@@ -579,7 +593,8 @@ Date format: `YYYY-MM-DD`
 ### Fixed
 ### Security
 
-[Unreleased]: https://github.com/sixafter/nanoid-cli/compare/v1.34.0...HEAD
+[Unreleased]: https://github.com/sixafter/nanoid-cli/compare/v1.35.0...HEAD
+[1.35.0]: https://github.com/sixafter/nanoid-cli/compare/v1.33.0...v1.34.0
 [1.34.0]: https://github.com/sixafter/nanoid-cli/compare/v1.33.0...v1.34.0
 [1.33.0]: https://github.com/sixafter/nanoid-cli/compare/v1.32.0...v1.33.0
 [1.32.0]: https://github.com/sixafter/nanoid-cli/compare/v1.31.2...v1.32.0

--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -7,6 +7,7 @@ package generate
 
 import (
 	"bufio"
+	"crypto/fips140"
 	"fmt"
 	"math"
 	"runtime"
@@ -47,7 +48,7 @@ If --count is not specified, one Nano ID is generated.`,
 }
 
 // runGenerate is the main execution function for the generate command
-func runGenerate(cmd *cobra.Command, args []string) error {
+func runGenerate(cmd *cobra.Command, _ []string) error {
 	// Validate id-length
 	if idLength <= 0 {
 		return writeString(cmd, "--id-length must be a positive integer")
@@ -56,6 +57,10 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 	// Validate count
 	if count <= 0 {
 		return writeString(cmd, "--count must be a positive integer")
+	}
+
+	if fips140.Enabled() {
+		_, _ = fmt.Fprintln(cmd.OutOrStderr(), "FIPS 140 mode is enabled; Nano ID generation is using a FIPS 140 compliant AES-CTR DRBG source.")
 	}
 
 	// Configure the Nano ID generator using ConfigOptions

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ go 1.25
 
 require (
 	github.com/dustin/go-humanize v1.0.1
-	github.com/sixafter/nanoid v1.49.0
+	github.com/sixafter/nanoid v1.50.0
 	github.com/sixafter/semver v1.7.0
 	github.com/spf13/cobra v1.10.1
 	github.com/stretchr/testify v1.11.1
@@ -19,6 +19,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/sixafter/aes-ctr-drbg v1.8.0 // indirect
 	github.com/sixafter/prng-chacha v1.4.0 // indirect
 	github.com/spf13/pflag v1.0.10 // indirect
 	golang.org/x/crypto v0.42.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,10 @@ github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLf
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/sixafter/nanoid v1.49.0 h1:iNlPKeaPDCPAgldyl9sly7rOq9WgAKDSYxTy1Y4Qj3I=
-github.com/sixafter/nanoid v1.49.0/go.mod h1:7X8fUEqGRf+OGqEnOyIEBk7oWqOjx9Bvgtau43psWWo=
+github.com/sixafter/aes-ctr-drbg v1.8.0 h1:cwhSmyTw8U+P01Zm+1ky64vu3VKB1YCaAOTwRvsmNSo=
+github.com/sixafter/aes-ctr-drbg v1.8.0/go.mod h1:k0MnzFOGf7ks7ixN/N72wQAT/7u+lIknQWa7H9Iqew4=
+github.com/sixafter/nanoid v1.50.0 h1:UGZUdl75wmox1ZVXZ97d0siD4Czigs+RvEpjnVV7DeY=
+github.com/sixafter/nanoid v1.50.0/go.mod h1:lQw1S4YVwoSPQXH4SWDbsKtNY3i7nUHp6/Y5NS6pg9A=
 github.com/sixafter/prng-chacha v1.4.0 h1:24MWhVL1hAF759TnFANdV4+CqhZXOltPxZuWnmV/aFI=
 github.com/sixafter/prng-chacha v1.4.0/go.mod h1:/qgtGyz1ueWauLV6JgIi6a2BNc/9IkLWXL98U2GEM7o=
 github.com/sixafter/semver v1.7.0 h1:kz3RPsy92e/WRD6kYi9/r1zdmC768ne9S9586KRD5pg=

--- a/vendor/github.com/sixafter/aes-ctr-drbg/.gitignore
+++ b/vendor/github.com/sixafter/aes-ctr-drbg/.gitignore
@@ -1,0 +1,32 @@
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+coverage.json
+testdata/
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+go.work.sum
+
+# env file
+.env
+
+.idea/
+.DS_Store
+
+dist/

--- a/vendor/github.com/sixafter/aes-ctr-drbg/.golangci.yaml
+++ b/vendor/github.com/sixafter/aes-ctr-drbg/.golangci.yaml
@@ -1,0 +1,78 @@
+# Copyright (c) 2024-2025 Six After, Inc.
+#
+# This source code is licensed under the Apache 2.0 License found in the
+# LICENSE file in the root directory of this source tree.
+
+# Ref: https://golangci-lint.run/usage/configuration/
+
+# See the dedicated "version" documentation section.
+version: "2"
+
+linters:
+  settings:
+    cyclop:
+      package-average: 20.0
+
+    funlen:
+      lines: 500
+      statements: 350
+
+    govet:
+      enable-all: true
+
+    makezero:
+      always: true
+
+  exclusions:
+    # Exclude certain directories from linting
+    paths:
+      - "vendor"
+      - "third_party"
+      - "generated"
+
+# Options for analysis running.
+run:
+  # The default concurrency value is the number of available CPU.
+  #concurrency: 4
+  # Timeout for analysis, e.g. 30s, 5m.
+  # Default: 1m
+  timeout: 2m
+  # Exit code when at least one issue was found.
+  # Default: 1
+  issues-exit-code: 1
+  # Include test files or not.
+  # Default: true
+  tests: false
+  # If set we pass it to "go list -mod={option}". From "go help modules":
+  # If invoked with -mod=readonly, the go command is disallowed from the implicit
+  # automatic updating of go.mod described above. Instead, it fails when any changes
+  # to go.mod are needed. This setting is most useful to check that go.mod does
+  # not need updates, such as in a continuous integration and testing system.
+  # If invoked with -mod=vendor, the go command assumes that the vendor
+  # directory holds the correct copies of dependencies and ignores
+  # the dependency descriptions in go.mod.
+  #
+  # Allowed values: readonly|vendor|mod
+  # By default, it isn't set.
+  modules-download-mode: readonly
+  # Allow multiple parallel golangci-lint instances running.
+  # If false (default) - golangci-lint acquires file lock on start.
+  allow-parallel-runners: false
+
+output:
+  # Order to use when sorting results.
+  # Possible values: `file`, `linter`, and `severity`.
+  #
+  # If the severity values are inside the following list, they are ordered in this order:
+  #   1. error
+  #   2. warning
+  #   3. high
+  #   4. medium
+  #   5. low
+  # Either they are sorted alphabetically.
+  #
+  # Default: ["linter", "file"]
+  sort-order:
+    - linter
+    - severity
+    - file # filepath, line, and column.

--- a/vendor/github.com/sixafter/aes-ctr-drbg/.goreleaser.yaml
+++ b/vendor/github.com/sixafter/aes-ctr-drbg/.goreleaser.yaml
@@ -1,0 +1,222 @@
+# Copyright (c) 2024-2025 Six After, Inc.
+#
+# This source code is licensed under the Apache 2.0 License found in the
+# LICENSE file in the root directory of this source tree.
+
+# yaml-language-server: $schema=https://goreleaser.com/static/schema.json
+# vim: set ts=2 sw=2 tw=0 fo=jcroql
+version: 2
+
+snapshot:
+  version_template: "{{ incpatch .Version }}-alpha"
+
+# Ref: https://goreleaser.com/customization/builds/
+project_name: aes-ctr-drbg
+
+builds:
+  # Ref: https://goreleaser.com/errors/no-main/#if-you-are-building-a-library
+  - skip: true
+
+# Ref: https://goreleaser.com/customization/changelog/
+changelog:
+  # Sorts the changelog by the commit's messages.
+  # Could either be asc, desc or empty
+  # Empty means 'no sorting', it'll use the output of `git log` as is.
+  sort: asc
+
+  # Changelog generation implementation to use.
+  #
+  # Valid options are:
+  # - `git`: uses `git log`;
+  # - `github`: uses the compare GitHub API, appending the author username to the changelog.
+  # - `gitlab`: uses the compare GitLab API, appending the author name and email to the changelog (requires a personal access token).
+  # - `gitea`: uses the compare Gitea API, appending the author username to the changelog.
+  # - `github-native`: uses the GitHub release notes generation API, disables the groups feature.
+  #
+  # Default: 'git'.
+  use: github
+
+  # Format to use for commit formatting.
+  #
+  # Templates: allowed.
+  #
+  # Default:
+  #    if 'git': '{{ .SHA }} {{ .Message }}'
+  #   otherwise: '{{ .SHA }}: {{ .Message }} ({{ with .AuthorUsername }}@{{ . }}{{ else }}{{ .AuthorName }} <{{ .AuthorEmail }}>{{ end }})'.
+  #
+  # Extra template fields:
+  # - `SHA`: the commit SHA1
+  # - `Message`: the first line of the commit message, otherwise known as commit subject
+  # - `AuthorName`: the author full name (considers mailmap if 'git')
+  # - `AuthorEmail`: the author email (considers mailmap if 'git')
+  # - `AuthorUsername`: github/gitlab/gitea username - not available if 'git'
+  #
+  # Usage with 'git': Since: v2.8.
+  format: "{{.SHA}}: {{.Message}} (@{{.AuthorUsername}})"
+
+  # Max commit hash length to use in the changelog.
+  #
+  # 0: use whatever the changelog implementation gives you
+  # -1: remove the commit hash from the changelog
+  # any other number: max length.
+  abbrev: 0
+
+  filters:
+    # Commit messages matching the regexp listed here will be the only ones
+    # added to the changelog
+    #
+    # If include is not-empty, exclude will be ignored.
+    #
+    # Matches are performed against the first line of the commit message only,
+    # prefixed with the commit SHA1, usually in the form of
+    # `<abbrev-commit>[:] <title-commit>`.
+    include:
+      - "(?i)^feature:"
+      - "(?i)^defect:"
+      - "(?i)^debt:"
+      - "(?i)^risk:"
+
+  # Group commits messages by given regex and title.
+  # Order value defines the order of the groups.
+  # Providing no regex means all commits will be grouped under the default group.
+  #
+  # Matches are performed against the first line of the commit message only,
+  # prefixed with the commit SHA1, usually in the form of
+  # `<abbrev-commit>[:] <title-commit>`.
+  # Groups are disabled when using github-native, as it already groups things by itself.
+  # Regex use RE2 syntax as defined here: https://github.com/google/re2/wiki/Syntax.
+  groups:
+    - title: "🎉 Features"
+      regexp: '(?i)^.*?feature(\([[:word:]]+\))??!?:.+$'
+      order: 0
+    - title: "🐛 Defects"
+      regexp: '(?i)^.*?defect(\([[:word:]]+\))??!?:.+$'
+      order: 1
+    - title: "🛠 Technical Debt"
+      regexp: '(?i)^.*?debt(\([[:word:]]+\))??!?:.+$'
+      order: 1
+    - title: "🚀 Technical Risk"
+      regexp: '(?i)^.*?risk(\([[:word:]]+\))??!?:.+$'
+      order: 1
+    - title: Others
+      order: 999
+
+# Ref: https://goreleaser.com/customization/checksums/
+checksum:
+  name_template: 'checksums.txt'
+
+# Ref: https://goreleaser.com/customization/sign/
+signs:
+  - id: source
+    cmd: cosign
+    stdin: '{{ .Env.COSIGN_PASSWORD }}'
+    output: true
+    artifacts: source
+    args:
+      - sign-blob
+      - --yes
+      - --key
+      - env://COSIGN_PRIVATE_KEY
+      - '--output-certificate=${certificate}'
+      - '--output-signature=${signature}'
+      - '${artifact}'
+
+  - id: checksums
+    cmd: cosign
+    stdin: '{{ .Env.COSIGN_PASSWORD }}'
+    output: true
+    artifacts: checksum
+    args:
+      - sign-blob
+      - --yes
+      - --key
+      - env://COSIGN_PRIVATE_KEY
+      - '--output-certificate=${certificate}'
+      - '--output-signature=${signature}'
+      - '${artifact}'
+
+# Ref: https://goreleaser.com/customization/source/
+source:
+  # Whether this pipe is enabled or not.
+  enabled: true
+
+  # Name template of the final archive.
+  #
+  # Default: '{{ .ProjectName }}-{{ .Version }}'.
+  # Templates: allowed.
+  name_template: "{{ .ProjectName }}-{{ .Version }}"
+
+  # Format of the archive.
+  #
+  # Valid formats are: tar, tgz, tar.gz, and zip.
+  #
+  # Default: 'tar.gz'.
+  format: tar.gz
+
+  # Prefix.
+  # String to prepend to each filename in the archive.
+  #
+  # Templates: allowed.
+  prefix_template: "{{ .ProjectName }}-{{ .Version }}/"
+
+  # You can add additional files if needed, or omit for default behavior.
+  # files:
+  #   - LICENSE
+  #   - README.md
+  # files:
+  #   - LICENSE
+  #   - README.md
+  #   - CHANGELOG/CHANGELOG*
+  #   - go.mod
+  #   - go.sum
+  #   - "*.go"
+  #   - "x/**/*"
+  #   - "vendor/**/*"
+
+# Ref: https://goreleaser.com/customization/sbom/
+sboms:
+  - # ID of the sbom config, must be unique.
+    #
+    # Default: 'default'.
+    id: default
+
+    # Which artifacts to catalog.
+    #
+    # Valid options are:
+    # - any:        let the SBOM tool decide which artifacts available in
+    #               the cwd should be cataloged
+    # - source:     source archive
+    # - package:    Linux packages (deb, rpm, apk, etc)
+    # - installer:  Windows MSI installers (Pro only)
+    # - diskimage:  macOS DMG disk images (Pro only)
+    # - archive:    archives from archive pipe
+    # - binary:     binaries output from the build stage
+    #
+    # Default: 'archive'.
+    artifacts: source
+
+    # IDs of the artifacts to catalog.
+    #
+    # If `artifacts` is "source" or "any" then this fields has no effect.
+    # ids:
+    #   - src
+
+# Ref: https://goreleaser.com/customization/release/
+release:
+  # Repo in which the release will be created.
+  # Default: extracted from the origin remote URL or empty if its private hosted.
+  github:
+    owner: sixafter
+    name: aes-ctr-drbg
+
+  # You can change the name of the release.
+  #
+  # Default: '{{.Tag}}' ('{{.PrefixedTag}}' on Pro).
+  # Templates: allowed.
+  name_template: 'v{{ .Version }}'
+
+  # Footer for the release body.
+  #
+  # Templates: allowed.
+  footer: |
+    **Full Changelog**: [CHANGELOG](https://github.com/sixafter/aes-ctr-drbg/tree/main/CHANGELOG/CHANGELOG-1.x.md)

--- a/vendor/github.com/sixafter/aes-ctr-drbg/CODEOWNERS
+++ b/vendor/github.com/sixafter/aes-ctr-drbg/CODEOWNERS
@@ -1,0 +1,37 @@
+# See https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners
+# for more details.
+
+# This is a comment.
+# Each line is a file pattern followed by one or more owners.
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for
+# review when someone opens a pull request.
+# *       @global-owner1 @global-owner2
+* @mprimeaux
+
+# Order is important; the last matching pattern takes the most
+# precedence. When someone opens a pull request that only
+# modifies JS files, only @js-owner and not the global
+# owner(s) will be requested for a review.
+# *.js    @js-owner
+
+# You can also use email addresses if you prefer. They'll be
+# used to look up users just like we do for commit author
+# emails.
+# *.go docs@example.com
+
+# The `docs/*` pattern will match files like
+# `docs/getting-started.md` but not further nested files like
+# `docs/build-app/troubleshooting.md`.
+# docs/*  docs@example.com
+
+# In this example, @octocat owns any file in an apps directory
+# anywhere in your repository.
+# apps/ @octocat
+
+# In this example, @doctocat owns any file in the `/docs`
+# directory in the root of your repository and any of its
+# subdirectories.
+# /docs/ @doctocat

--- a/vendor/github.com/sixafter/aes-ctr-drbg/CODE_OF_CONDUCT.md
+++ b/vendor/github.com/sixafter/aes-ctr-drbg/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[INSERT CONTACT METHOD].
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/vendor/github.com/sixafter/aes-ctr-drbg/CONTRIBUTING.md
+++ b/vendor/github.com/sixafter/aes-ctr-drbg/CONTRIBUTING.md
@@ -1,0 +1,166 @@
+# Contributing
+
+Thank you for your interest in contributing to **AES-CTR-DRBG**! Your contributions help make this project better for everyone. This guide outlines the process for contributing to the project, including reporting issues, submitting pull requests, and adhering to the project's code of conduct.
+
+## 📜 Table of Contents
+
+- [Code of Conduct](#code-of-conduct)
+- [How to Contribute](#how-to-contribute)
+    - [Reporting Bugs](#reporting-bugs)
+    - [Requesting Features](#requesting-features)
+    - [Submitting Changes](#submitting-changes)
+- [Coding Guidelines](#coding-guidelines)
+    - [Style Guidelines](#style-guidelines)
+- [Security Considerations](#-security-considerations)
+- [Pull Request Process](#pull-request-process)
+---
+
+## 🛡️ Code of Conduct
+
+This project adheres to the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to [osint@sixafter.com](mailto:osint@sixafter.com).
+
+---
+
+## Versioning
+
+This software adheres to the [Semantic Versioning 2.0](https://semver.org/spec/v2.0.0.html) standard for version numbering as quoted here:
+
+Given a version number MAJOR.MINOR.PATCH, increment the:
+
+1.	MAJOR version when you make incompatible API changes
+2.	MINOR version when you add functionality in a backward compatible manner
+3.	PATCH version when you make backward compatible bug fixes
+
+Additional labels for pre-release and build metadata are available as extensions to the MAJOR.MINOR.PATCH format.
+
+---
+
+## 🤝 How to Contribute
+
+There are several ways you can contribute:
+
+### 🐛 Reporting Bugs
+
+If you encounter a bug or unexpected behavior:
+
+1. **Search Existing Issues**: Check if the issue has already been reported [here](https://github.com/sixafter/aes-ctr-drbg/issues).
+2. **Open a New Issue**: If not, open a new issue describing the bug in detail.
+    - **Provide a Clear Title**: Summarize the problem.
+    - **Describe the Behavior**: Explain what you expected to happen versus what actually happened.
+    - **Steps to Reproduce**: Include code snippets or commands that can help reproduce the issue.
+    - **Environment Details**: Mention your Go version, operating system, and any other relevant information.
+
+### 🌟 Requesting Features
+
+To suggest new features or improvements:
+
+1. **Search Existing Features**: Ensure your idea hasn't been discussed [here](https://github.com/sixafter/aes-ctr-drbg/issues?q=is%3Aissue+is%3Aopen+label%3Afeature).
+2. **Open a New Feature Request**: Provide a detailed description of the feature.
+    - **Describe the Feature**: Explain what the feature is and why it's needed.
+    - **Use Cases**: Provide examples of how the feature would be used.
+    - **Potential Implementation**: If possible, suggest how it could be implemented.
+
+### ✨ Submitting Changes
+
+Contributions in the form of bug fixes, improvements, or new features are welcome!
+
+#### 1. Fork the Repository
+
+Fork the repository to your GitHub account by clicking the **Fork** button at the top right of the repository page.
+
+#### 2. Clone Your Fork
+
+Clone the forked repository to your local machine:
+
+```bash
+git clone https://github.com/sixafter/aes-ctr-drbg.git
+cd aes-ctr-drbg
+```
+
+#### 3. Create a New Branch
+
+Create a new branch for your changes:
+
+```bash
+git checkout -b feature/your-feature-name
+```
+
+#### 4. Make Your Changes
+
+#### 5. Run Tests and Linters
+
+Ensure all tests pass and the code adheres to the style guidelines:
+
+```bash
+make lint
+make test
+```
+
+#### 6. Commit Your Changes
+
+Commit your changes with a clear and descriptive message:
+
+```bash
+git add .
+git commit -m "Add descriptive commit message"
+```
+
+#### 7. Push to Your Fork
+
+Push your changes to your forked repository:
+
+```bash
+git push origin feature/your-feature-name
+```
+
+#### 8. Open a Pull Request
+
+Navigate to the original repository and click New Pull Request. Provide a clear description of your changes and link any related issues.
+
+## 🎨 Coding Guidelines
+
+Adhering to consistent coding standards ensures the codebase remains clean, readable, and maintainable.
+
+### 🖋️ Style Guidelines
+
+* **Formatting**: Use `make fmt` to format your code. 
+* **Linting**: Follow the linting rules defined in `.golangci.yaml`. Ensure that your code passes all linters before submitting. 
+* **Documentation**: Document public functions, types, and methods using Go's standard documentation conventions. 
+* **Error Handling**: Handle errors gracefully and consistently. Use the predefined error types where applicable.
+
+---
+
+## 🔒 Security Considerations
+
+* **Randomness**: Ensure that all randomness sources use cryptographically secure methods (crypto/rand). 
+* **Data Sanitization**: Avoid exposing sensitive data through IDs or logs.
+
+---
+
+## 🚀 Pull Request Process
+
+Follow these steps to create a successful pull request (PR):
+
+1. Ensure Your Branch is Up-to-Date
+   * Before opening a PR, make sure your branch is based on the latest main branch.
+2. Create a Pull Request 
+3. Address Feedback 
+   * **Respond Promptly**: Engage with reviewers by responding to comments and making necessary changes. 
+   * **Update Your PR**: Push additional commits to your branch to address feedback.
+4. Merge the PR 
+   * Once approved and all checks pass, your PR will be merged by a maintainer.
+
+---
+
+## 📝 Additional Resources
+
+* [Go Documentation](https://go.dev/doc/) 
+* [GolangCI-Lint Documentation](https://golangci-lint.run) 
+* [GitHub Flow](https://docs.github.com/en/get-started/using-github/github-flow) 
+* [Contributor Covenant Code of Conduct](https://github.com/sixafter/aes-ctr-drbg/blob/main/CODE_OF_CONDUCT.md)
+
+## 🙏 Thank You!
+
+We appreciate your interest in contributing to AES-CTR-DRBG! Your efforts help improve the project and support the community. If you have any questions or need assistance, feel free to reach out by opening an issue or contacting the maintainers.
+
+Happy coding! 🎉

--- a/vendor/github.com/sixafter/aes-ctr-drbg/FIPS-140.md
+++ b/vendor/github.com/sixafter/aes-ctr-drbg/FIPS-140.md
@@ -1,0 +1,51 @@
+# FIPS 140 Compliance
+
+> **IMPORTANT:**  
+> This package is *not* itself FIPS 140 validated or certified. See below for details on compatibility and limitations.
+
+## Overview
+
+This package is designed to operate within FIPS 140-2 and FIPS 140-3 validated environments, leveraging only the Go standard library cryptographic primitives. No custom or third-party cryptography is used.
+
+## Compatibility with Go FIPS 140 Mode
+
+Go provides a dedicated FIPS 140 mode, enabled with the environment variable `GODEBUG=fips140=on` or `GODEBUG=fips140=1`. When enabled, this mode restricts cryptographic operations to those explicitly permitted under the FIPS 140 standard, and applies additional runtime checks to enforce compliance.
+
+This package is engineered for **full compatibility with Go’s FIPS 140 mode**:
+
+- **All cryptographic operations** use only Go standard library algorithms.
+- **No prohibited or non-standard cryptography** is invoked when FIPS mode is active.
+- **No inclusion** of third-party or experimental crypto.
+
+When Go’s FIPS 140 mode is active, any use of non-approved cryptography results in a runtime error, providing enforcement at the platform level.
+
+## Important Limitations and Legal Notice
+
+- **This package is not independently validated or certified under FIPS 140 by NIST or any authority.**  
+  Operation within a FIPS-validated environment is supported, but this alone does not provide FIPS validation.
+- **Go FIPS 140 mode does not grant FIPS 140 validation or certification.**  
+  It only enforces approved algorithm use when run with a FIPS-validated Go runtime and platform.
+- **Setting `GODEBUG=fips140=on` is enforcement, not certification.**  
+  Your responsibility is to ensure the Go runtime, cryptographic libraries, and the OS are all FIPS-validated if you require formal compliance.
+- **No warranty or guarantee of FIPS 140 compliance is expressed or implied.**  
+  Regulatory compliance is the responsibility of the deploying organization.
+
+## Reference: Go FIPS 140 Documentation
+
+For further technical guidance and up-to-date status on FIPS 140 support in Go, consult the official documentation:
+
+- [Go FIPS 140 Documentation](https://go.dev/doc/security/fips140)
+
+## Recommendations for Deploying in FIPS-Regulated Environments
+
+- **Deploy only on FIPS-validated platforms:**  
+  Ensure the OS, Go runtime, and underlying crypto modules have valid FIPS 140 certifications.
+- **Audit your deployment:**  
+  Regularly review your supply chain, build, and deployment process for compliance.
+- **Consult compliance and security professionals:**  
+  Engage your organization’s legal and compliance teams to ensure your deployment meets all requirements.
+- **Retain and review certifications:**  
+  For compliance reporting, use only official documentation and certification records.
+
+> **Disclaimer:**  
+> Use of this package in FIPS-regulated environments is at your own risk. No warranty, express or implied, is provided regarding FIPS 140 compliance. This package is distributed “as is” and must be reviewed and validated as part of your organization’s own compliance and certification process.

--- a/vendor/github.com/sixafter/aes-ctr-drbg/LICENSE
+++ b/vendor/github.com/sixafter/aes-ctr-drbg/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/sixafter/aes-ctr-drbg/Makefile
+++ b/vendor/github.com/sixafter/aes-ctr-drbg/Makefile
@@ -17,7 +17,7 @@ GO_MOD=$(GO_CMD) mod
 GO_LINT_CMD=golangci-lint run
 GO_WORK=$(GO_CMD) work
 GO_WORK_FILE := ./go.work
-FUZZTIME ?= 15s
+FUZZTIME ?= 25s
 
 .PHONY: all
 all: deps vendor update vendor tidy clean test
@@ -27,26 +27,27 @@ deps: ## Get the dependencies and vendor
 	@./scripts/go-deps.sh
 
 .PHONY: test
-test: ## Execute unit tests (default and FIPS mode)
-	@echo "==> Running tests (default mode)"
+test: ## Execute unit tests
 	$(GO_TEST) -v ./...
-
-	@echo ""
-	@echo "==> Running tests (FIPS mode: GODEBUG=fips140=on)"
-	GODEBUG=fips140=on $(GO_TEST) -v ./...
 
 .PHONY: fuzz
 fuzz: ## Run each Go fuzz test individually (10s per test)
-	@for fuzz in FuzzNewWithLength FuzzCustomAlphabet FuzzCustomGenerator FuzzRead; do \
+	@for fuzz in Fuzz_Reader_Read Fuzz_Reader_Concurrent Fuzz_NewReader_AllOptions Fuzz_NewReader_Personalization Fuzz_NewReader_Buffers; do \
 		echo "===> Fuzzing $$fuzz"; \
-		$(GO_TEST) -v -run=^$$ -fuzz=$$fuzz -fuzztime=$(FUZZTIME) || exit $$?; \
+		$(GO_TEST) -v -fuzz=$$fuzz -fuzztime=$(FUZZTIME) || exit $$?; \
 	done
 
 .PHONY: bench
-bench: ## Execute benchmark tests for NanoID
+bench: ## Execute benchmark tests for AES-CTR-DRBG (raw bytes).
 	@rm -f cpu.out
 	@rm -f mem.out
-	$(GO_TEST) -bench=. -run=^$$ -benchmem -memprofile=mem.out -cpuprofile=cpu.out
+	$(GO_TEST) -bench='^BenchmarkDRBG_' -run=^$$ -benchmem -memprofile=mem.out -cpuprofile=cpu.out .
+
+.PHONY: bench-uuid
+bench-uuid: ## Execute benchmark tests for using the AES-CTR-DRBG to generate UUIDs using Google's uuid package.
+	@rm -f cpu.out
+	@rm -f mem.out
+	$(GO_TEST) -bench='^BenchmarkUUID_' -run=^$$ -benchmem -memprofile=mem.out -cpuprofile=cpu.out .
 
 .PHONY: clean
 clean: ## Remove previous build

--- a/vendor/github.com/sixafter/aes-ctr-drbg/README.md
+++ b/vendor/github.com/sixafter/aes-ctr-drbg/README.md
@@ -1,0 +1,516 @@
+# AES-CTR-DRBG
+
+[![Go Report Card](https://goreportcard.com/badge/github.com/sixafter/aes-ctr-drbg)](https://goreportcard.com/report/github.com/sixafter/aes-ctr-drbg)
+[![License: Apache 2.0](https://img.shields.io/badge/license-Apache%202.0-blue?style=flat-square)](LICENSE)
+[![Go](https://img.shields.io/github/go-mod/go-version/sixafter/aes-ctr-drbg)](https://img.shields.io/github/go-mod/go-version/sixafter/aes-ctr-drbg)
+[![Go Reference](https://pkg.go.dev/badge/github.com/sixafter/aes-ctr-drbg.svg)](https://pkg.go.dev/github.com/sixafter/aes-ctr-drbg)
+[![FIPS‑140 Mode Compatible](https://img.shields.io/badge/FIPS‑140--Mode-Compatible-brightgreen)](FIPS‑140.md)
+
+---
+
+## Status
+
+### Build & Test
+
+[![CI](https://github.com/sixafter/aes-ctr-drbg/workflows/ci/badge.svg)](https://github.com/sixafter/aes-ctr-drbg/actions)
+[![GitHub issues](https://img.shields.io/github/issues/sixafter/aes-ctr-drbg)](https://github.com/sixafter/aes-ctr-drbg/issues)
+
+### Quality
+
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=six-after_aes-ctr-drbg&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=six-after_aes-ctr-drbg)
+![CodeQL](https://github.com/sixafter/aes-ctr-drbg/actions/workflows/codeql-analysis.yaml/badge.svg)
+[![Security Rating](https://sonarcloud.io/api/project_badges/measure?project=six-after_aes-ctr-drbg&metric=security_rating)](https://sonarcloud.io/summary/new_code?id=six-after_aes-ctr-drbg)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/sixafter/aes-ctr-drbg/badge)](https://scorecard.dev/viewer/?uri=github.com/sixafter/aes-ctr-drbg)
+
+### Package and Deploy
+
+[![Release](https://github.com/sixafter/aes-ctr-drbg/workflows/release/badge.svg)](https://github.com/sixafter/aes-ctr-drbg/actions)
+
+---
+## Overview 
+
+AES-CTR-DRBG (Deterministic Random Bit Generator based on AES in Counter mode) is a cryptographically secure pseudo-random number generator (CSPRNG) defined by [NIST SP 800-90A Rev. 1](https://csrc.nist.gov/pubs/sp/800/90/a/r1/final). It's widely used in high-assurance systems, including those requiring [FIPS 140-2](https://csrc.nist.gov/pubs/fips/140-2/upd2/final) compliance. 
+AES-CTR-DRBG is designed for environments requiring deterministic, reproducible, and FIPS‑140-compatible random bit generation. This module is suitable for any application that needs strong cryptographic assurance or must comply with regulated environments (e.g., FedRAMP, FIPS, PCI, HIPAA). 
+
+The module uses only Go standard library crypto primitives (`crypto/aes` and `crypto/cipher`), making it safe for use in FIPS 140-validated Go runtimes. No third-party, homegrown, or experimental ciphers are used.
+
+Please see the [godoc](https://pkg.go.dev/github.com/sixafter/aes-ctr-drbg) for detailed documentation.
+
+---
+
+## FIPS‑140 Mode
+
+See [FIPS‑140.md](FIPS-140.md) for compliance, deployment, and configuration guidance.
+
+---
+
+## Features
+
+* **Standards-Compliant Implementation:**
+  Implements NIST SP 800-90A, Revision 1 AES-CTR-DRBG using the Go standard library (`crypto/aes`, `crypto/cipher`). Supports 128-, 192-, and 256-bit keys. State and counter management strictly adhere to the specification.
+
+* **FIPS 140-2 Alignment:**
+  Designed for use in FIPS 140-2 validated environments and compatible with Go’s FIPS 140 mode (`GODEBUG=fips140=on`). See [FIPS-140.md](FIPS-140.md) for platform guidance.
+
+* **Zero-Allocation Output Path:**
+  The DRBG is engineered for `0 allocs/op` in its standard `io.Reader` output path, enabling predictable resource usage and high throughput.
+
+* **Asynchronous Key Rotation:**
+  Supports automatic key rotation after a configurable number of bytes have been generated (`MaxBytesPerKey`). Rekeying occurs asynchronously with exponential backoff and configurable retry limits, reducing long-term key exposure.
+
+* **Prediction Resistance Mode:**
+  Supports NIST SP 800-90A prediction resistance. When enabled, the DRBG reseeds from system entropy before every output, as required for state compromise resilience.
+
+* **Sharded Pooling for Concurrency:**
+  Internal state pooling can be sharded across multiple `sync.Pool` instances. The number of shards is configurable, allowing improved performance under concurrent workloads.
+
+* **Extensive Functional Configuration:**
+  Exposes a comprehensive set of functional options, including:
+
+  * AES key size (128/192/256-bit)
+  * Maximum output per key (rekey threshold)
+  * Personalization string (domain separation)
+  * Shard/pool count
+  * Reseed interval and request count
+  * Buffer size controls
+  * Key rotation and rekey backoff parameters
+  * Prediction resistance
+  * Fork detection and reseeding
+
+* **Thread-Safe and Deterministic:**
+  All DRBG instances are safe for concurrent use. Output is deterministic for a given seed and personalization.
+
+* **io.Reader Compatibility:**
+  Implements Go’s `io.Reader` interface for drop-in use as a secure random source.
+
+* **No External Dependencies:**
+  Depends exclusively on the Go standard library for cryptographic operations.
+
+* **UUID Generation:**
+  Can be used as a cryptographically secure `io.Reader` with the [`google/uuid`](https://pkg.go.dev/github.com/google/uuid) package and similar libraries.
+
+* **Comprehensive Testing and Fuzzing:**
+  Includes property-based, fuzz, concurrency, and allocation tests to validate correctness, robustness, and allocation characteristics.
+
+* **Fork-Safety:**
+  Automatic detection and reseeding on process fork. This library automatically detects process forks and reseeds in the child process to prevent random stream duplication. No manual action is required.
+
+## NIST SP 800-90A Compliance
+
+For a detailed mapping between the implementation and NIST SP 800-90A requirements, see [NIST-SP-800-90A.md](docs/NIST-SP-800-90A.md).
+
+---
+
+## Verify with Cosign
+
+[Cosign](https://github.com/sigstore/cosign) is used to sign releases for integrity verification.
+
+To verify the integrity of the release tarball, you can use Cosign to check the signature and checksums. Follow these steps:
+
+```sh
+# Fetch the latest release tag from GitHub API (e.g., "v1.8.0")
+TAG=$(curl -s https://api.github.com/repos/sixafter/aes-ctr-drbg/releases/latest | jq -r .tag_name)
+
+# Remove leading "v" for filenames (e.g., "v1.8.0" -> "1.8.0")
+VERSION=${TAG#v}
+
+# Verify the release tarball
+cosign verify-blob \
+  --key https://raw.githubusercontent.com/sixafter/aes-ctr-drbg/main/cosign.pub \
+  --signature aes-ctr-drbg-${VERSION}.tar.gz.sig \
+  aes-ctr-drbg-${VERSION}.tar.gz
+
+# Download checksums.txt and its signature from the latest release assets
+curl -LO https://github.com/sixafter/aes-ctr-drbg/releases/download/${TAG}/checksums.txt
+curl -LO https://github.com/sixafter/aes-ctr-drbg/releases/download/${TAG}/checksums.txt.sig
+
+# Verify checksums.txt with cosign
+cosign verify-blob \
+  --key https://raw.githubusercontent.com/sixafter/aes-ctr-drbg/main/cosign.pub \
+  --signature checksums.txt.sig \
+  checksums.txt
+```
+
+If valid, Cosign will output:
+
+```shell
+Verified OK
+```
+
+---
+
+## Installation
+
+```bash
+go get -u github.com/sixafter/aes-ctr-drbg
+```
+
+---
+
+## Usage
+
+### Basic Usage: Generate Secure Random Bytes With Reader
+
+```go
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/sixafter/aes-ctr-drbg"
+)
+
+func main() {
+	buf := make([]byte, 64)
+	n, err := ctrdrbg.Reader.Read(buf)
+	if err != nil {
+		log.Fatalf("failed to read random bytes: %v", err)
+	}
+	fmt.Printf("Read %d random bytes: %x\n", n, buf)
+}
+```
+
+### Basic Usage: Generate Secure Random Bytes with NewReader
+
+```go
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/sixafter/aes-ctr-drbg"
+)
+
+func main() {
+	// Example: AES-256 (32 bytes) key
+	r, err := ctrdrbg.NewReader(ctrdrbg.WithKeySize(ctrdrbg.KeySize256))
+	if err != nil {
+		log.Fatalf("failed to create ctrdrbg.Reader: %v", err)
+	}
+
+	buf := make([]byte, 64)
+	n, err := r.Read(buf)
+	if err != nil {
+		log.Fatalf("failed to read random bytes: %v", err)
+	}
+	fmt.Printf("Read %d random bytes: %x\n", n, buf)
+}
+```
+
+### Using Personalization and Additional Input
+
+```go
+package main
+
+import (
+	"fmt"
+	"log"
+
+	"github.com/sixafter/aes-ctr-drbg"
+)
+
+func main() {
+	r, err := ctrdrbg.NewReader(
+		ctrdrbg.WithPersonalization([]byte("service-id-1")),
+		ctrdrbg.WithKeySize(ctrdrbg.KeySize256), // AES-256
+	)
+	if err != nil {
+		log.Fatalf("failed to create ctrdrbg.Reader: %v", err)
+	}
+
+	buf := make([]byte, 64)
+	n, err := r.Read(buf)
+	if err != nil {
+		log.Fatalf("failed to read random bytes: %v", err)
+	}
+	fmt.Printf("Read %d random bytes: %x\n", n, buf)
+}
+```
+
+---
+
+## Performance Benchmarks
+
+### Raw Random Byte Generation
+
+These `ctrdrbg.Reader` benchmarks demonstrate the package's focus on minimizing latency, memory usage, and allocation overhead, making it suitable for high-performance applications.
+
+<details>
+  <summary>Expand to see results</summary>
+
+```shell
+make bench
+go test -bench='^BenchmarkDRBG_' -run=^$ -benchmem -memprofile=mem.out -cpuprofile=cpu.out .
+goos: darwin
+goarch: arm64
+pkg: github.com/sixafter/aes-ctr-drbg
+cpu: Apple M4 Max
+BenchmarkDRBG_SyncPool_Baseline_Concurrent/G2-16  	1000000000	         0.6696 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_SyncPool_Baseline_Concurrent/G4-16  	1000000000	         0.6740 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_SyncPool_Baseline_Concurrent/G8-16  	1000000000	         0.6520 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_SyncPool_Baseline_Concurrent/G16-16 	1000000000	         0.6885 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_SyncPool_Baseline_Concurrent/G32-16 	1000000000	         0.6353 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_SyncPool_Baseline_Concurrent/G64-16 	1000000000	         0.6401 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_SyncPool_Baseline_Concurrent/G128-16         	1000000000	         0.6474 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Serial/Serial_Read_16Bytes-16           	29874123	        36.11 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Serial/Serial_Read_32Bytes-16           	28411921	        42.00 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Serial/Serial_Read_64Bytes-16           	22326446	        53.37 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Serial/Serial_Read_256Bytes-16          	 9796570	       122.1 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Serial/Serial_Read_512Bytes-16          	 5619010	       213.4 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Serial/Serial_Read_4096Bytes-16         	  798786	      1470 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Serial/Serial_Read_16384Bytes-16        	  203523	      5781 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Concurrent/Concurrent_Read_16Bytes_2Goroutines-16         	19856755	        86.58 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Concurrent/Concurrent_Read_16Bytes_4Goroutines-16         	19652169	        84.27 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Concurrent/Concurrent_Read_16Bytes_8Goroutines-16         	19535383	        88.98 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Concurrent/Concurrent_Read_16Bytes_16Goroutines-16        	19280488	        88.56 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Concurrent/Concurrent_Read_16Bytes_32Goroutines-16        	18911883	        88.54 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Concurrent/Concurrent_Read_16Bytes_64Goroutines-16        	20954308	        81.26 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Concurrent/Concurrent_Read_16Bytes_128Goroutines-16       	20513842	        73.62 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Concurrent/Concurrent_Read_32Bytes_2Goroutines-16         	18478191	        75.79 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Concurrent/Concurrent_Read_32Bytes_4Goroutines-16         	19357531	        74.66 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Concurrent/Concurrent_Read_32Bytes_8Goroutines-16         	20106480	        86.12 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Concurrent/Concurrent_Read_32Bytes_16Goroutines-16        	19378123	        74.65 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Concurrent/Concurrent_Read_32Bytes_32Goroutines-16        	19684783	        77.99 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Concurrent/Concurrent_Read_32Bytes_64Goroutines-16        	19942705	        78.12 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Concurrent/Concurrent_Read_32Bytes_128Goroutines-16       	20817882	        60.40 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Concurrent/Concurrent_Read_64Bytes_2Goroutines-16         	19866068	        75.31 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Concurrent/Concurrent_Read_64Bytes_4Goroutines-16         	19591770	        87.64 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Concurrent/Concurrent_Read_64Bytes_8Goroutines-16         	19219963	        76.07 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Concurrent/Concurrent_Read_64Bytes_16Goroutines-16        	19804158	        79.80 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Concurrent/Concurrent_Read_64Bytes_32Goroutines-16        	19630122	        67.15 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Concurrent/Concurrent_Read_64Bytes_64Goroutines-16        	19981904	        78.98 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Concurrent/Concurrent_Read_64Bytes_128Goroutines-16       	19985551	        81.36 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Concurrent/Concurrent_Read_256Bytes_2Goroutines-16        	10538402	       160.8 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Concurrent/Concurrent_Read_256Bytes_4Goroutines-16        	10828724	       161.7 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Concurrent/Concurrent_Read_256Bytes_8Goroutines-16        	10997553	       158.9 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Concurrent/Concurrent_Read_256Bytes_16Goroutines-16       	10632771	       161.5 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Concurrent/Concurrent_Read_256Bytes_32Goroutines-16       	10377925	       160.6 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Concurrent/Concurrent_Read_256Bytes_64Goroutines-16       	10851642	       148.4 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Concurrent/Concurrent_Read_256Bytes_128Goroutines-16      	11019211	       158.4 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Concurrent/Concurrent_Read_512Bytes_2Goroutines-16        	10556665	       153.7 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Concurrent/Concurrent_Read_512Bytes_4Goroutines-16        	10974860	       160.1 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Concurrent/Concurrent_Read_512Bytes_8Goroutines-16        	11132241	       156.5 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Concurrent/Concurrent_Read_512Bytes_16Goroutines-16       	10818664	       154.8 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Concurrent/Concurrent_Read_512Bytes_32Goroutines-16       	10574911	       162.6 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Concurrent/Concurrent_Read_512Bytes_64Goroutines-16       	11106015	       158.2 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Concurrent/Concurrent_Read_512Bytes_128Goroutines-16      	11131617	       157.8 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Concurrent/Concurrent_Read_4096Bytes_2Goroutines-16       	 7474005	       221.3 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Concurrent/Concurrent_Read_4096Bytes_4Goroutines-16       	 6751184	       219.0 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Concurrent/Concurrent_Read_4096Bytes_8Goroutines-16       	 5899460	       220.4 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Concurrent/Concurrent_Read_4096Bytes_16Goroutines-16      	 6126216	       220.6 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Concurrent/Concurrent_Read_4096Bytes_32Goroutines-16      	 6938299	       220.1 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Concurrent/Concurrent_Read_4096Bytes_64Goroutines-16      	 7048448	       215.8 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Concurrent/Concurrent_Read_4096Bytes_128Goroutines-16     	 7366938	       206.9 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Concurrent/Concurrent_Read_16384Bytes_2Goroutines-16      	 1439043	       826.1 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Concurrent/Concurrent_Read_16384Bytes_4Goroutines-16      	 1478479	       851.5 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Concurrent/Concurrent_Read_16384Bytes_8Goroutines-16      	 1434871	       812.5 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Concurrent/Concurrent_Read_16384Bytes_16Goroutines-16     	 1692771	       682.5 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Concurrent/Concurrent_Read_16384Bytes_32Goroutines-16     	 1452622	       847.3 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Concurrent/Concurrent_Read_16384Bytes_64Goroutines-16     	 1626038	       844.8 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_Concurrent/Concurrent_Read_16384Bytes_128Goroutines-16    	 1523498	       847.4 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_LargeSizes_Sequential/Serial_Read_Large_4096Bytes-16      	  778651	      1476 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_LargeSizes_Sequential/Serial_Read_Large_16384Bytes-16     	  208345	      5873 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_LargeSizes_Sequential/Serial_Read_Large_65536Bytes-16     	   51400	     23373 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_LargeSizes_Sequential/Serial_Read_Large_1048576Bytes-16   	    3177	    381062 ns/op	      11 B/op	       0 allocs/op
+BenchmarkDRBG_Read_LargeSizes_Concurrent/Concurrent_Read_Large_4096Bytes_2Goroutines-16         	 7376702	       221.4 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_LargeSizes_Concurrent/Concurrent_Read_Large_4096Bytes_4Goroutines-16         	 5193856	       213.5 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_LargeSizes_Concurrent/Concurrent_Read_Large_4096Bytes_8Goroutines-16         	 6114523	       224.6 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_LargeSizes_Concurrent/Concurrent_Read_Large_4096Bytes_16Goroutines-16        	 7188720	       205.1 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_LargeSizes_Concurrent/Concurrent_Read_Large_4096Bytes_32Goroutines-16        	 7138792	       217.6 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_LargeSizes_Concurrent/Concurrent_Read_Large_4096Bytes_64Goroutines-16        	 5875122	       221.0 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_LargeSizes_Concurrent/Concurrent_Read_Large_4096Bytes_128Goroutines-16       	 6167787	       219.8 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_LargeSizes_Concurrent/Concurrent_Read_Large_16384Bytes_2Goroutines-16        	 1475030	       831.7 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_LargeSizes_Concurrent/Concurrent_Read_Large_16384Bytes_4Goroutines-16        	 1454176	       806.5 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_LargeSizes_Concurrent/Concurrent_Read_Large_16384Bytes_8Goroutines-16        	 1561255	       809.1 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_LargeSizes_Concurrent/Concurrent_Read_Large_16384Bytes_16Goroutines-16       	 1520268	       835.0 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_LargeSizes_Concurrent/Concurrent_Read_Large_16384Bytes_32Goroutines-16       	 1454516	       839.5 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_LargeSizes_Concurrent/Concurrent_Read_Large_16384Bytes_64Goroutines-16       	 1456448	       837.4 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_LargeSizes_Concurrent/Concurrent_Read_Large_16384Bytes_128Goroutines-16      	 1503434	       807.8 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_LargeSizes_Concurrent/Concurrent_Read_Large_65536Bytes_2Goroutines-16        	  481670	      2853 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_LargeSizes_Concurrent/Concurrent_Read_Large_65536Bytes_4Goroutines-16        	  436726	      2932 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_LargeSizes_Concurrent/Concurrent_Read_Large_65536Bytes_8Goroutines-16        	  467893	      2903 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_LargeSizes_Concurrent/Concurrent_Read_Large_65536Bytes_16Goroutines-16       	  473342	      2837 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_LargeSizes_Concurrent/Concurrent_Read_Large_65536Bytes_32Goroutines-16       	  474193	      2911 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_LargeSizes_Concurrent/Concurrent_Read_Large_65536Bytes_64Goroutines-16       	  462038	      2924 ns/op	       1 B/op	       0 allocs/op
+BenchmarkDRBG_Read_LargeSizes_Concurrent/Concurrent_Read_Large_65536Bytes_128Goroutines-16      	  475135	      2924 ns/op	       1 B/op	       0 allocs/op
+BenchmarkDRBG_Read_LargeSizes_Concurrent/Concurrent_Read_Large_1048576Bytes_2Goroutines-16      	   29137	     42209 ns/op	       3 B/op	       0 allocs/op
+BenchmarkDRBG_Read_LargeSizes_Concurrent/Concurrent_Read_Large_1048576Bytes_4Goroutines-16      	   29096	     42039 ns/op	       3 B/op	       0 allocs/op
+BenchmarkDRBG_Read_LargeSizes_Concurrent/Concurrent_Read_Large_1048576Bytes_8Goroutines-16      	   29031	     41666 ns/op	       4 B/op	       0 allocs/op
+BenchmarkDRBG_Read_LargeSizes_Concurrent/Concurrent_Read_Large_1048576Bytes_16Goroutines-16     	   28812	     41482 ns/op	       7 B/op	       0 allocs/op
+BenchmarkDRBG_Read_LargeSizes_Concurrent/Concurrent_Read_Large_1048576Bytes_32Goroutines-16     	   29179	     41477 ns/op	      10 B/op	       0 allocs/op
+BenchmarkDRBG_Read_LargeSizes_Concurrent/Concurrent_Read_Large_1048576Bytes_64Goroutines-16     	   29031	     42093 ns/op	      17 B/op	       0 allocs/op
+BenchmarkDRBG_Read_LargeSizes_Concurrent/Concurrent_Read_Large_1048576Bytes_128Goroutines-16    	   28680	     42144 ns/op	      20 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes/Serial_Read_Variable_16Bytes-16                                	32761209	        35.89 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes/Serial_Read_Variable_32Bytes-16                                	28607130	        41.87 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes/Serial_Read_Variable_64Bytes-16                                	22548178	        53.11 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes/Serial_Read_Variable_128Bytes-16                               	15760812	        76.34 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes/Serial_Read_Variable_256Bytes-16                               	 9770961	       122.5 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes/Serial_Read_Variable_512Bytes-16                               	 5631610	       213.4 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes/Serial_Read_Variable_1024Bytes-16                              	 3079610	       395.7 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes/Serial_Read_Variable_2048Bytes-16                              	 1599415	       757.3 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes/Serial_Read_Variable_4096Bytes-16                              	  805844	      1500 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_16Bytes_2Goroutines-16     	18766542	        90.00 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_16Bytes_4Goroutines-16     	19131636	        87.84 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_16Bytes_8Goroutines-16     	18264330	        88.93 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_16Bytes_16Goroutines-16    	19677601	        83.92 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_16Bytes_32Goroutines-16    	19468838	        86.37 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_16Bytes_64Goroutines-16    	19406863	        86.51 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_16Bytes_128Goroutines-16   	18875232	        85.87 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_32Bytes_2Goroutines-16     	18813998	        70.36 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_32Bytes_4Goroutines-16     	19586839	        73.45 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_32Bytes_8Goroutines-16     	19415864	        87.21 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_32Bytes_16Goroutines-16    	18120147	        84.09 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_32Bytes_32Goroutines-16    	19511706	        81.57 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_32Bytes_64Goroutines-16    	19756026	        85.11 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_32Bytes_128Goroutines-16   	19666300	        84.13 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_64Bytes_2Goroutines-16     	18756825	        89.42 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_64Bytes_4Goroutines-16     	16706818	        80.92 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_64Bytes_8Goroutines-16     	19674012	        86.17 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_64Bytes_16Goroutines-16    	17465998	        87.80 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_64Bytes_32Goroutines-16    	19747316	        82.86 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_64Bytes_64Goroutines-16    	19630255	        77.58 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_64Bytes_128Goroutines-16   	20142564	        70.42 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_128Bytes_2Goroutines-16    	11142530	       143.1 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_128Bytes_4Goroutines-16    	10331701	       144.2 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_128Bytes_8Goroutines-16    	11674490	       129.5 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_128Bytes_16Goroutines-16   	 8749474	       124.9 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_128Bytes_32Goroutines-16   	11025412	       117.2 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_128Bytes_64Goroutines-16   	11193232	       116.4 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_128Bytes_128Goroutines-16  	10937000	       108.3 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_256Bytes_2Goroutines-16    	 9248961	       111.8 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_256Bytes_4Goroutines-16    	11058454	       134.8 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_256Bytes_8Goroutines-16    	11100536	       121.2 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_256Bytes_16Goroutines-16   	10285585	       115.0 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_256Bytes_32Goroutines-16   	10852808	       107.5 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_256Bytes_64Goroutines-16   	 9899952	       123.4 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_256Bytes_128Goroutines-16  	11235616	       130.8 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_512Bytes_2Goroutines-16    	10088126	       110.2 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_512Bytes_4Goroutines-16    	 8867764	       147.6 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_512Bytes_8Goroutines-16    	 8720042	       115.7 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_512Bytes_16Goroutines-16   	11546450	       120.1 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_512Bytes_32Goroutines-16   	10706088	       119.0 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_512Bytes_64Goroutines-16   	10183741	       140.5 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_512Bytes_128Goroutines-16  	11463069	       103.3 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_1024Bytes_2Goroutines-16   	12553362	        95.83 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_1024Bytes_4Goroutines-16   	12499902	        95.99 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_1024Bytes_8Goroutines-16   	12535980	        93.40 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_1024Bytes_16Goroutines-16  	12506155	        95.98 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_1024Bytes_32Goroutines-16  	12727627	        93.93 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_1024Bytes_64Goroutines-16  	12669898	        94.98 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_1024Bytes_128Goroutines-16 	12720594	        93.38 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_2048Bytes_2Goroutines-16   	12157644	        99.74 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_2048Bytes_4Goroutines-16   	12303175	       100.5 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_2048Bytes_8Goroutines-16   	11785392	       100.0 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_2048Bytes_16Goroutines-16  	11959412	       118.3 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_2048Bytes_32Goroutines-16  	12079330	       109.1 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_2048Bytes_64Goroutines-16  	11362237	       103.0 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_2048Bytes_128Goroutines-16 	11637774	       120.4 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_4096Bytes_2Goroutines-16   	 6880490	       168.8 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_4096Bytes_4Goroutines-16   	 7228526	       168.8 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_4096Bytes_8Goroutines-16   	 7195345	       169.0 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_4096Bytes_16Goroutines-16  	 7188027	       168.1 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_4096Bytes_32Goroutines-16  	 7118646	       168.9 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_4096Bytes_64Goroutines-16  	 7124090	       172.9 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_VariableSizes_Concurrent/Concurrent_Read_Variable_4096Bytes_128Goroutines-16 	 7097014	       169.6 ns/op	       0 B/op	       0 allocs/op
+BenchmarkDRBG_Read_ExtremeSizes/Serial_Read_Extreme_10485760Bytes-16                            	     295	   3929851 ns/op	     224 B/op	       0 allocs/op
+BenchmarkDRBG_Read_ExtremeSizes/Concurrent_Read_Extreme_10485760Bytes_2Goroutines-16            	    3172	    381380 ns/op	      91 B/op	       0 allocs/op
+BenchmarkDRBG_Read_ExtremeSizes/Concurrent_Read_Extreme_10485760Bytes_4Goroutines-16            	    2817	    380624 ns/op	     117 B/op	       0 allocs/op
+BenchmarkDRBG_Read_ExtremeSizes/Concurrent_Read_Extreme_10485760Bytes_8Goroutines-16            	    3079	    384180 ns/op	     127 B/op	       0 allocs/op
+BenchmarkDRBG_Read_ExtremeSizes/Concurrent_Read_Extreme_10485760Bytes_16Goroutines-16           	    3080	    385891 ns/op	     159 B/op	       0 allocs/op
+BenchmarkDRBG_Read_ExtremeSizes/Concurrent_Read_Extreme_10485760Bytes_32Goroutines-16           	    2972	    398988 ns/op	     156 B/op	       1 allocs/op
+BenchmarkDRBG_Read_ExtremeSizes/Concurrent_Read_Extreme_10485760Bytes_64Goroutines-16           	    2919	    403091 ns/op	     167 B/op	       1 allocs/op
+BenchmarkDRBG_Read_ExtremeSizes/Concurrent_Read_Extreme_10485760Bytes_128Goroutines-16          	    2972	    397429 ns/op	     284 B/op	       2 allocs/op
+BenchmarkDRBG_Read_ExtremeSizes/Serial_Read_Extreme_52428800Bytes-16                            	      54	  19975266 ns/op	    1222 B/op	       1 allocs/op
+BenchmarkDRBG_Read_ExtremeSizes/Concurrent_Read_Extreme_52428800Bytes_2Goroutines-16            	     608	   1995378 ns/op	     352 B/op	       1 allocs/op
+BenchmarkDRBG_Read_ExtremeSizes/Concurrent_Read_Extreme_52428800Bytes_4Goroutines-16            	     553	   2018336 ns/op	     428 B/op	       2 allocs/op
+BenchmarkDRBG_Read_ExtremeSizes/Concurrent_Read_Extreme_52428800Bytes_8Goroutines-16            	     566	   2034392 ns/op	     511 B/op	       2 allocs/op
+BenchmarkDRBG_Read_ExtremeSizes/Concurrent_Read_Extreme_52428800Bytes_16Goroutines-16           	     558	   1969891 ns/op	     547 B/op	       3 allocs/op
+BenchmarkDRBG_Read_ExtremeSizes/Concurrent_Read_Extreme_52428800Bytes_32Goroutines-16           	     588	   1971865 ns/op	     505 B/op	       3 allocs/op
+BenchmarkDRBG_Read_ExtremeSizes/Concurrent_Read_Extreme_52428800Bytes_64Goroutines-16           	     571	   2006916 ns/op	     914 B/op	       7 allocs/op
+BenchmarkDRBG_Read_ExtremeSizes/Concurrent_Read_Extreme_52428800Bytes_128Goroutines-16          	     573	   1977134 ns/op	    1045 B/op	      11 allocs/op
+BenchmarkDRBG_Read_ExtremeSizes/Serial_Read_Extreme_104857600Bytes-16                           	      28	  39731435 ns/op	    1663 B/op	       2 allocs/op
+BenchmarkDRBG_Read_ExtremeSizes/Concurrent_Read_Extreme_104857600Bytes_2Goroutines-16           	     286	   3826714 ns/op	     619 B/op	       3 allocs/op
+BenchmarkDRBG_Read_ExtremeSizes/Concurrent_Read_Extreme_104857600Bytes_4Goroutines-16           	     266	   3791460 ns/op	     740 B/op	       3 allocs/op
+BenchmarkDRBG_Read_ExtremeSizes/Concurrent_Read_Extreme_104857600Bytes_8Goroutines-16           	     274	   3849177 ns/op	     752 B/op	       4 allocs/op
+BenchmarkDRBG_Read_ExtremeSizes/Concurrent_Read_Extreme_104857600Bytes_16Goroutines-16          	     278	   3827166 ns/op	     846 B/op	       5 allocs/op
+BenchmarkDRBG_Read_ExtremeSizes/Concurrent_Read_Extreme_104857600Bytes_32Goroutines-16          	     292	   3948489 ns/op	    1099 B/op	       8 allocs/op
+BenchmarkDRBG_Read_ExtremeSizes/Concurrent_Read_Extreme_104857600Bytes_64Goroutines-16          	     300	   3867839 ns/op	    1226 B/op	      11 allocs/op
+BenchmarkDRBG_Read_ExtremeSizes/Concurrent_Read_Extreme_104857600Bytes_128Goroutines-16         	     289	   3847689 ns/op	    1528 B/op	      18 allocs/op
+BenchmarkDRBG_Read_WithKeyRotation-16                                                           	 5003805	       238.5 ns/op	     198 B/op	       1 allocs/op
+BenchmarkDRBG_Read_PredictionResistance-16                                                      	 2632755	       456.1 ns/op	     634 B/op	       3 allocs/op
+PASS
+ok  	github.com/sixafter/aes-ctr-drbg	291.367s
+```
+
+</details>
+
+### UUID Generation with Google UUID and ctrdrbg
+
+Here's a summary of the benchmark results comparing the default random reader for Google's [UUID](https://pkg.go.dev/github.com/google/uuid) package and the ctrdrbg-based UUID generation:
+
+| Benchmark Scenario                  | Default ns/op | CTRDRBG ns/op | % Faster (ns/op) | Default B/op | CTRDRBG B/op | Default allocs/op | CTRDRBG allocs/op |
+|-------------------------------------|--------------:|--------------:|-----------------:|-------------:|-------------:|------------------:|------------------:|
+| v4 Serial                           |        180.6  |        40.78  |         77.4%    |         16   |         16   |                1  |                1  |
+| v4 Parallel                         |        445.4  |        10.56  |         97.6%    |         16   |         16   |                1  |                1  |
+| v4 Concurrent (2 goroutines)        |        413.2  |        21.91  |         94.7%    |         16   |         16   |                1  |                1  |
+| v4 Concurrent (4 goroutines)        |        428.5  |        12.77  |         97.0%    |         16   |         16   |                1  |                1  |
+| v4 Concurrent (8 goroutines)        |        484.6  |         9.74  |         98.0%    |         16   |         16   |                1  |                1  |
+| v4 Concurrent (16 goroutines)       |        458.2  |         7.67  |         98.3%    |         16   |         16   |                1  |                1  |
+| v4 Concurrent (32 goroutines)       |        506.3  |         7.69  |         98.5%    |         16   |         16   |                1  |                1  |
+| v4 Concurrent (64 goroutines)       |        506.9  |         7.64  |         98.5%    |         16   |         16   |                1  |                1  |
+| v4 Concurrent (128 goroutines)      |        508.2  |         7.63  |         98.5%    |         16   |         16   |                1  |                1  |
+| v4 Concurrent (256 goroutines)      |        511.8  |         7.79  |         98.5%    |         16   |         16   |                1  |                1  |
+
+Notes:
+- "Default" refers to the baseline Go `crypto/rand` source.
+- "CTRDRBG" refers to this AES-CTR-DRBG implementation.
+- "% Faster (ns/op)" is computed as `100 * (Default - CTRDRBG) / Default`, rounded.
+
+<details>
+  <summary>Expand to see results</summary>
+
+  ```shell
+make bench-uuid
+go test -bench='^BenchmarkUUID_' -run=^$ -benchmem -memprofile=mem.out -cpuprofile=cpu.out .
+goos: darwin
+goarch: arm64
+pkg: github.com/sixafter/aes-ctr-drbg
+cpu: Apple M4 Max
+BenchmarkUUID_v4_Default_Serial-16        	 6473760	       180.6 ns/op	      16 B/op	       1 allocs/op
+BenchmarkUUID_v4_Default_Parallel-16      	 2705866	       445.4 ns/op	      16 B/op	       1 allocs/op
+BenchmarkUUID_v4_Default_Concurrent/Goroutines_2-16         	 2883284	       413.2 ns/op	      16 B/op	       1 allocs/op
+BenchmarkUUID_v4_Default_Concurrent/Goroutines_4-16         	 2806682	       428.5 ns/op	      16 B/op	       1 allocs/op
+BenchmarkUUID_v4_Default_Concurrent/Goroutines_8-16         	 2462146	       484.6 ns/op	      16 B/op	       1 allocs/op
+BenchmarkUUID_v4_Default_Concurrent/Goroutines_16-16        	 2685201	       458.2 ns/op	      16 B/op	       1 allocs/op
+BenchmarkUUID_v4_Default_Concurrent/Goroutines_32-16        	 2366074	       506.3 ns/op	      16 B/op	       1 allocs/op
+BenchmarkUUID_v4_Default_Concurrent/Goroutines_64-16        	 2358429	       506.9 ns/op	      16 B/op	       1 allocs/op
+BenchmarkUUID_v4_Default_Concurrent/Goroutines_128-16       	 2388648	       508.2 ns/op	      16 B/op	       1 allocs/op
+BenchmarkUUID_v4_Default_Concurrent/Goroutines_256-16       	 2364384	       511.8 ns/op	      16 B/op	       1 allocs/op
+BenchmarkUUID_v4_CTRDRBG_Serial-16                          	29120706	        40.78 ns/op	      16 B/op	       1 allocs/op
+BenchmarkUUID_v4_CTRDRBG_Parallel-16                        	100000000	        10.56 ns/op	      16 B/op	       1 allocs/op
+BenchmarkUUID_v4_CTRDRBG_Concurrent/Goroutines_2-16         	52686843	        21.91 ns/op	      16 B/op	       1 allocs/op
+BenchmarkUUID_v4_CTRDRBG_Concurrent/Goroutines_4-16         	92968908	        12.77 ns/op	      16 B/op	       1 allocs/op
+BenchmarkUUID_v4_CTRDRBG_Concurrent/Goroutines_8-16         	121979662	         9.741 ns/op	      16 B/op	       1 allocs/op
+BenchmarkUUID_v4_CTRDRBG_Concurrent/Goroutines_16-16        	153623710	         7.668 ns/op	      16 B/op	       1 allocs/op
+BenchmarkUUID_v4_CTRDRBG_Concurrent/Goroutines_32-16        	154797238	         7.688 ns/op	      16 B/op	       1 allocs/op
+BenchmarkUUID_v4_CTRDRBG_Concurrent/Goroutines_64-16        	156757164	         7.641 ns/op	      16 B/op	       1 allocs/op
+BenchmarkUUID_v4_CTRDRBG_Concurrent/Goroutines_128-16       	156462766	         7.632 ns/op	      16 B/op	       1 allocs/op
+BenchmarkUUID_v4_CTRDRBG_Concurrent/Goroutines_256-16       	154197008	         7.795 ns/op	      16 B/op	       1 allocs/op
+PASS
+ok  	github.com/sixafter/aes-ctr-drbg	33.515s
+  ```
+</details>
+
+---
+
+## Contributing
+
+Contributions are welcome. See [CONTRIBUTING](CONTRIBUTING.md)
+
+---
+
+## License
+
+This project is licensed under the [Apache 2.0 License](https://choosealicense.com/licenses/apache-2.0/). See [LICENSE](LICENSE) file.

--- a/vendor/github.com/sixafter/aes-ctr-drbg/SECURITY.md
+++ b/vendor/github.com/sixafter/aes-ctr-drbg/SECURITY.md
@@ -1,0 +1,9 @@
+# Security Policy
+
+## Supported Versions
+
+Patches will be released to the latest major version.
+
+## Reporting a Vulnerability
+
+Please report (suspected) security vulnerabilities to [security@sixafter.com](mailto:security@sixafter.com). If the issue is confirmed, we will release a patch as soon as possible depending on complexity.

--- a/vendor/github.com/sixafter/aes-ctr-drbg/aes_ctr_drbg.go
+++ b/vendor/github.com/sixafter/aes-ctr-drbg/aes_ctr_drbg.go
@@ -1,0 +1,1125 @@
+// Copyright (c) 2024-2025 Six After, Inc
+//
+// This source code is licensed under the Apache 2.0 License found in the
+// LICENSE file in the root directory of this source tree.
+
+// Package ctrdrbg provides a FIPS 140-2 aligned, high-performance AES-CTR-DRBG.
+//
+// This package implements a cryptographically secure, pool-backed Deterministic Random Bit Generator
+// (DRBG) following the NIST SP 800-90A AES-CTR-DRBG construction, specifically as defined in
+// Section 10.2.1 of NIST SP 800-90A Rev. 1 ("Recommendation for Random Number Generation Using
+// Deterministic Random Bit Generators").
+//
+// Each generator instance uses an AES block cipher in counter (CTR) mode to produce cryptographically
+// secure pseudo-random bytes, suitable for high-throughput, concurrent workloads.
+//
+// All cryptographic primitives are provided by the Go standard library. This implementation is designed
+// for environments requiring strong compliance, including support for Go's FIPS-140 mode (GODEBUG=fips140=on).
+//
+// Reference:
+//
+//	NIST Special Publication 800-90A Rev. 1, Section 10.2.1 (CTR_DRBG Construction)
+//	https://nvlpubs.nist.gov/nistpubs/SpecialPublications/NIST.SP.800-90Ar1.pdf
+package ctrdrbg
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"fmt"
+	"io"
+	mrand "math/rand/v2"
+	"os"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// Reader is a package-level, cryptographically secure random source suitable for high-concurrency applications.
+//
+// Reader is initialized at package load time via NewReader and is safe for concurrent use. If initialization fails
+// (for example, if crypto/rand is unavailable), the package will panic. This ensures that any failure to obtain a secure
+// entropy source is detected immediately and not silently ignored.
+//
+// Example usage:
+//
+//	buf := make([]byte, 64)
+//	_, err := ctrdrbg.Reader.Read(buf)
+//	if err != nil {
+//	    // handle error
+//	}
+//	fmt.Printf("Random data: %x\n", buf)
+var Reader io.Reader
+
+// Interface defines the contract for a NIST SP 800-90A AES-CTR-DRBG random source.
+//
+// Implementations provide cryptographically secure random bytes via io.Reader,
+// and expose the non-secret, immutable configuration used at construction time.
+//
+// All methods are safe for concurrent use unless otherwise specified.
+//
+// The Config() method returns a copy of the DRBG's configuration. This allows inspection
+// of operational parameters without exposing secrets or runtime-internal state.
+type Interface interface {
+	io.Reader
+
+	// Config returns a copy of the DRBG configuration in use by this instance.
+	// The returned Config does not include secrets or mutable runtime state.
+	Config() Config
+
+	// Reseed injects new entropy and optional additional input, refreshing the DRBG state.
+	//
+	// Per NIST SP 800-90A, additionalInput is combined with system entropy and
+	// personalization (if set) to derive a new internal key and counter.
+	// Reseed can be called at any time to proactively refresh the DRBG.
+	//
+	// Returns an error if the reseed operation fails.
+	Reseed(additionalInput []byte) error
+
+	// ReadWithAdditionalInput generates cryptographically secure random bytes,
+	// supplementing system entropy with optional per-call additional input.
+	//
+	// This method is NIST-compliant and allows callers to inject additional
+	// entropy or context for a single Read operation.
+	// If PredictionResistance is enabled, additionalInput is ignored and fresh entropy is always used.
+	//
+	// Returns the number of bytes read (equal to len(b)) and an error (if any).
+	ReadWithAdditionalInput(b []byte, additionalInput []byte) (int, error)
+}
+
+// init initializes the package-level Reader. It panics if NewReader fails, preventing operation without
+// a secure random source. This follows cryptographic best practices by making entropy failure a fatal error.
+func init() {
+	cfg := DefaultConfig()
+	pools, err := initShardPools(cfg)
+	if err != nil {
+		panic(fmt.Sprintf("ctrdrbg: failed to initialize pools: %v", err))
+	}
+
+	Reader = &reader{pools: pools}
+}
+
+// initShardPools creates and validates all sync.Pool shards for concurrent DRBG use.
+//
+// For each shard, a sync.Pool is created whose New function constructs a DRBG instance using the provided config.
+// If instantiation fails, it retries up to MaxInitRetries times, then panics if unsuccessful.
+// After creating each pool, it is eagerly tested by borrowing and returning an instance, to ensure failures are
+// caught at construction rather than at first use.
+//
+// If any pool.New panics (due to repeated DRBG initialization failure), the function recovers and returns the
+// error to the caller (for use in NewReader). In package-level init, a panic is allowed to abort process startup.
+//
+// Parameters:
+//   - cfg: Config specifying DRBG options (shard count, retries, etc.)
+//
+// Returns:
+//   - []*sync.Pool: slice of initialized pools, one per shard.
+//   - error: non-nil if pool initialization panicked for any shard.
+func initShardPools(cfg Config) ([]*sync.Pool, error) {
+	// Create a slice of sync.Pool pointers, one for each shard.
+	pools := make([]*sync.Pool, cfg.Shards)
+	for i := range pools {
+		// Capture the config by value for use in the pool.New closure (avoids loop variable capture bug).
+		capturedCfg := cfg
+		pools[i] = &sync.Pool{
+			New: func() interface{} {
+				var d *drbg
+				var err error
+				// Attempt to instantiate a DRBG instance, retrying up to MaxInitRetries times.
+				for r := 0; r < capturedCfg.MaxInitRetries; r++ {
+					if d, err = newDRBG(&capturedCfg); err == nil {
+						return d
+					}
+				}
+				// If all attempts fail, panic (either for fatal startup or to be caught below).
+				panic(fmt.Sprintf("ctrdrbg pool init failed after %d retries: %v", capturedCfg.MaxInitRetries, err))
+			},
+		}
+
+		// Eagerly test pool initialization to ensure catastrophic failures are caught immediately,
+		// not deferred until first use. If New panics, recover and convert it to an error.
+		var panicErr error
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					panicErr = fmt.Errorf("ctrdrbg pool initialization failed: %v", r)
+				}
+			}()
+			item := pools[i].Get()
+			pools[i].Put(item)
+		}()
+
+		// If initialization panicked, return error immediately.
+		if panicErr != nil {
+			return nil, panicErr
+		}
+	}
+
+	return pools, nil
+}
+
+// reader is an internal implementation of io.Reader that uses a pool of DRBG instances
+// to support efficient concurrent random byte generation.
+type reader struct {
+	pools []*sync.Pool
+}
+
+// NewReader constructs and returns an io.Reader that produces cryptographically secure
+// random bytes using a pool of AES-CTR-DRBG instances. Functional options may be supplied to customize key size,
+// key rotation, and pool behavior. Each generator is seeded with entropy from crypto/rand.
+//
+// The returned Reader is safe for concurrent use. If no generator can be created after MaxInitRetries,
+// NewReader returns an error.
+//
+// Example:
+//
+//	r, err := ctrdrbg.NewReader(ctrdrbg.WithKeySize(ctrdrbg.KeySize256))
+//	if err != nil {
+//	    // handle error
+//	}
+//
+//	buf := make([]byte, 32)
+//	n, err := r.Read(buf)
+//	if err != nil {
+//	    // handle error
+//	}
+//	fmt.Printf("Read %d bytes: %x\n", n, buf)
+func NewReader(opts ...Option) (Interface, error) {
+	// Start with a default configuration, then apply each functional option to mutate cfg.
+	cfg := DefaultConfig()
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	// Validate the configured key size is appropriate for AES.
+	// Only 16, 24, or 32 bytes (AES-128, AES-192, AES-256) are supported.
+	switch cfg.KeySize {
+	case KeySize128, KeySize192, KeySize256:
+	default:
+		return nil, fmt.Errorf("invalid key size %d bytes; must be 16, 24, or 32", cfg.KeySize)
+	}
+
+	if cfg.MaxInitRetries < 1 {
+		return nil, fmt.Errorf("invalid MaxInitRetries: must be >= 1")
+	}
+
+	// Initialize the shard pools using the validated configuration.
+	pools, err := initShardPools(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	//  Return a new reader that wraps the initialized pool.
+	return &reader{pools: pools}, nil
+}
+
+// Config returns a copy of the deterministic random bit generator’s static configuration.
+//
+// This method exposes only non-sensitive configuration options as set at initialization.
+// No secret key material, runtime state, or internal DRBG details are included in the result.
+// The returned Config is a copy and safe for inspection or serialization.
+func (r *reader) Config() Config {
+	// It's safe to fetch from any pool, as all configs are the same.
+	d := r.pools[0].Get().(*drbg)
+	cfg := *d.config
+	r.pools[0].Put(d)
+	return cfg
+}
+
+// Reseed refreshes the state of all DRBG instances in all shard pools with new entropy and optional additional input.
+//
+// This method implements the Interface contract for NIST SP 800-90A compliant deterministic random bit generators.
+// For each DRBG instance managed by the pool, Reseed obtains fresh entropy from the system entropy source and
+// combines it with the provided additionalInput and the configured personalization string, per NIST recommendations.
+// This operation ensures that each DRBG instance has a newly derived key and counter (V), providing domain separation
+// and supporting explicit entropy injection for compliance, recovery, or defense-in-depth.
+//
+// Parameters:
+//   - additionalInput []byte: Optional per-call entropy or domain-separation input to be mixed into the reseed.
+//     May be nil if no additional input is required.
+//
+// Returns:
+//   - error: Returns the first error encountered if any DRBG instance fails to reseed; otherwise returns nil.
+//
+// Security and Compliance Notes:
+//   - Reseed is safe for concurrent use and may be called at any time during operation.
+//   - If called while DRBGs are in use, subsequent reads will immediately begin using the newly seeded state.
+//   - This is required for some FIPS and high-assurance applications, and is recommended for recovery from suspected
+//     entropy pool compromise or for regulatory compliance triggers.
+//
+// Example usage:
+//
+//	err := reader.Reseed([]byte("audit-event-timestamp"))
+//	if err != nil {
+//	    log.Fatalf("reseed failed: %v", err)
+//	}
+func (r *reader) Reseed(additionalInput []byte) error {
+	// Iterate over each sync.Pool in the shard pool array.
+	for _, pool := range r.pools {
+		// Borrow a DRBG instance from the pool.
+		d := pool.Get().(*drbg)
+		// Attempt to reseed this DRBG instance using the provided additionalInput.
+		// Reseed will combine system entropy, personalization, and additionalInput as per NIST.
+		err := d.Reseed(additionalInput)
+		// Return the DRBG instance to the pool for future reuse, regardless of success.
+		pool.Put(d)
+		// If reseed fails for any DRBG, immediately return the error to the caller.
+		if err != nil {
+			return err
+		}
+	}
+	// If all DRBGs reseeded successfully, return nil.
+	return nil
+}
+
+// shardIndex selects a pseudo-random shard index in the range [0, n) using
+// a fast, thread-safe global PCG64-based RNG.
+//
+// This function is used to evenly distribute load across multiple sync.Pool
+// shards, reducing contention in high-concurrency scenarios. It avoids the
+// overhead of time-based seeding or mutex contention.
+//
+// The randomness is not cryptographically secure but is safe for concurrent
+// use and sufficient for load balancing purposes.
+//
+// Panics if n <= 0.
+func shardIndex(n int) int {
+	return mrand.IntN(n)
+}
+
+// ReadWithAdditionalInput fills the provided buffer with cryptographically secure random bytes,
+// optionally supplementing system entropy with caller-provided additionalInput, per NIST SP 800-90A.
+//
+// This method enables advanced consumers to inject per-call entropy, external event data, or
+// session context into the DRBG reseed process, as specified by the NIST DRBG "additional input" feature.
+// If PredictionResistance is enabled on the DRBG configuration, the additionalInput argument is ignored
+// and fresh entropy is always used as required by the standard.
+//
+// Parameters:
+//   - b []byte: The output buffer to fill with random bytes. Must be non-nil; may be zero-length.
+//   - additionalInput []byte: Optional per-call entropy or context for NIST-compliant reseed. May be nil.
+//
+// Returns:
+//   - int: The number of bytes written to b (always len(b) unless b is empty).
+//   - error: Error returned if random generation fails; nil on success.
+//
+// Concurrency and Pooling:
+//   - This method is safe for concurrent use. The underlying DRBG instance is selected from an internal pool
+//     using a sharding strategy to maximize throughput and minimize contention.
+//
+// Security and Compliance Notes:
+//   - additionalInput is cryptographically mixed with system entropy and personalization (if any) for this call only.
+//   - If PredictionResistance is enabled, additionalInput is ignored and reseed is always performed from entropy.
+//   - For most use cases, use the standard Read method. This method is intended for regulatory, compliance, or
+//     advanced event-driven entropy injection scenarios.
+//
+// Example usage:
+//
+//	n, err := reader.ReadWithAdditionalInput(buf, []byte("user-event-entropy"))
+//	if err != nil {
+//	    // handle error
+//	}
+func (r *reader) ReadWithAdditionalInput(b []byte, additionalInput []byte) (int, error) {
+	// Determine number of pools (shards) in the reader for load balancing.
+	n := len(r.pools)
+	shard := 0
+	// For multiple shards, select a random shard index for this call.
+	if n > 1 {
+		shard = shardIndex(n)
+	}
+	// Borrow a DRBG instance from the selected pool for this operation.
+	d := r.pools[shard].Get().(*drbg)
+	// Ensure the instance is returned to the pool after use (even on error or panic).
+	defer r.pools[shard].Put(d)
+	// Fill the buffer using the borrowed DRBG, injecting additionalInput as specified.
+	return d.ReadWithAdditionalInput(b, additionalInput)
+}
+
+// Read fills the provided buffer with cryptographically secure random data.
+//
+// Read implements the io.Reader interface and is designed to be safe for concurrent use when accessed
+// via the package-level Reader or any Reader returned from NewReader.
+//
+// Example:
+//
+//	buffer := make([]byte, 32)
+//	n, err := Reader.Read(buffer)
+//	if err != nil {
+//	    // Handle error
+//	}
+//	fmt.Printf("Read %d bytes of random data: %x\n", n, buffer)
+func (r *reader) Read(b []byte) (int, error) {
+	// Return immediately if the buffer is empty, as required by the io.Reader contract.
+	if len(b) == 0 {
+		return 0, nil
+	}
+
+	// Determine the shard index based on the number of pools available.
+	n := len(r.pools)
+	shard := 0
+	if n > 1 {
+		shard = shardIndex(n)
+	}
+
+	// Borrow an instance of the internal deterministic random bit generator from the pool.
+	// This ensures that each call gets exclusive access to an isolated state for cryptographic safety.
+	d := r.pools[shard].Get().(*drbg)
+
+	// Ensure that the borrowed instance is returned to the pool, even if Read fails or panics.
+	// This pattern prevents resource leaks and maintains pool integrity.
+	defer r.pools[shard].Put(d)
+
+	// Fill the caller’s buffer with random data using the borrowed generator.
+	// The actual cryptographic work is performed by the internal generator’s Read method.
+	return d.Read(b)
+}
+
+// state encapsulates the immutable cryptographic state of the DRBG, excluding the counter.
+// This state is swapped atomically on rekey.
+type state struct {
+	// block is the initialized AES cipher.Block used in CTR mode.
+	//
+	// AES-CTR transforms the block cipher into a stream cipher by
+	// encrypting a counter and XOR-ing it with plaintext to produce
+	// pseudorandom output bytes.
+	block cipher.Block
+
+	// key holds the internal DRBG secret key used for AES-CTR operations.
+	//
+	// The key length is determined by config.KeySize and can be:
+	// - 16 bytes for AES-128
+	// - 24 bytes for AES-192
+	// - 32 bytes for AES-256
+	//
+	// Unused bytes are zeroed and ignored.
+	key [32]byte
+
+	// v is the 128-bit internal counter (NIST "V") used by the DRBG.
+	//
+	// This counter is incremented for each AES block to produce a unique
+	// keystream segment in CTR mode. It ensures deterministic, non-repeating output.
+	v [16]byte
+}
+
+// drbg represents an internal deterministic random bit generator (DRBG) implementing
+// the io.Reader interface using the NIST SP 800-90A AES-CTR-DRBG construction.
+//
+// Each drbg instance is intended to be used by a single goroutine at a time and is not
+// safe for concurrent use. It maintains its own AES cipher, secret key, counter, usage counter,
+// and rekeying flag for key rotation.
+//
+// This implementation ensures FIPS 140-2 alignment, strong security, and high performance
+// under concurrent workloads by separating immutable cryptographic state (managed atomically)
+// from the evolving counter (protected by a mutex).
+type drbg struct {
+	// config holds the immutable configuration for this DRBG instance.
+	//
+	// Includes:
+	// - AES key size (e.g., 16, 24, or 32 bytes)
+	// - Personalization string for domain separation
+	// - Automatic key rotation policy
+	// - Pool initialization and retry settings
+	config *Config
+
+	// state is an atomic pointer to the immutable cryptographic state for this DRBG.
+	//
+	// This state includes:
+	//   - AES block cipher (used in CTR mode)
+	//   - Secret key material
+	//   - Initial counter value (NIST "V") at creation or rekey
+	//
+	// The atomic pointer allows for fast, race-free swapping of key/counter/cipher state
+	// during asynchronous rekeying, without impacting ongoing read operations.
+	state atomic.Pointer[state]
+
+	// lastReseedTime records the time of the last successful reseed.
+	// Used to determine if the configured ReseedInterval has elapsed and
+	// automatic reseeding should occur before the next output.
+	lastReseedTime time.Time
+
+	// zero is a preallocated slice of zero-filled bytes used for output buffering.
+	//
+	// When UseZeroBuffer is enabled in config, this buffer is XOR-ed with
+	// AES-CTR output to efficiently produce random bytes. Sized dynamically as needed.
+	zero []byte
+
+	// vMu is a mutex protecting the evolving counter (v) for this DRBG instance.
+	//
+	// All access and mutation of v must occur with this mutex held to ensure:
+	//   - Counter advancement is atomic and non-overlapping across reads
+	//   - Proper persistence of the counter value between consecutive reads
+	//   - Safe resetting of the counter during key rotation (rekey)
+	vMu sync.Mutex
+
+	// v is the current 128-bit internal counter (NIST "V") for the DRBG instance.
+	//
+	// This counter is incremented for each AES block produced, ensuring
+	// unique, non-repeating output for every call to Read. It is initialized
+	// from the state.v value at creation or rekey, and persisted between reads.
+	v [16]byte
+
+	// requests counts the number of output requests (calls to Read or ReadWithAdditionalInput)
+	// since the last reseed. Used to enforce the ReseedRequests limit and trigger reseeding
+	// after a configured number of requests.
+	requests uint64
+
+	// usage tracks the number of bytes generated since the last key rotation.
+	//
+	// When usage exceeds config.MaxBytesPerKey, a rekey is triggered to ensure
+	// forward secrecy and mitigate key compromise risk. This value is atomically updated.
+	usage uint64
+
+	// rekeying is an atomic flag (0 or 1) that guards rekey attempts.
+	//
+	// It ensures that only one goroutine performs rekeying at a time.
+	// Uses atomic operations for concurrency safety.
+	rekeying uint32
+
+	// pid caches the process identifier (PID) of the operating system process in which
+	// this DRBG instance was most recently initialized or reseeded.
+	//
+	// Purpose:
+	//   - Enables robust detection of process-level forks (e.g., via fork(2) or similar system calls).
+	//   - After a fork, the child process receives a new, unique PID, but the DRBG instance initially
+	//     retains the PID from its parent process.
+	//   - By comparing the current process PID (os.Getpid()) to this cached value, the DRBG can reliably
+	//     detect fork events at runtime.
+	//   - When a fork is detected, the DRBG securely reseeds its cryptographic state, preventing random
+	//     stream duplication and ensuring forward and backward security in both parent and child processes.
+	//
+	// Security Rationale:
+	//   - Eliminates the risk of duplicated random streams following a process fork—a known pitfall of
+	//     userspace CSPRNGs in forking environments (Linux, macOS).
+	//   - Aligns the safety guarantees of userspace DRBGs with those provided by kernel-backed CSPRNGs,
+	//     such as Linux getrandom(2), which handle fork-safety internally.
+	pid int
+
+	// encV is a persistent [16]byte working buffer used as a session-local counter
+	// during output generation.
+	//
+	// On each call to Read, the current counter value (d.v) is copied into encV, which is
+	// then incremented and used for block generation throughout the request. Only after all
+	// output is produced is encV copied back into d.v, ensuring atomic and consistent counter
+	// advancement. This prevents partial or inconsistent counter updates if Read exits early
+	// due to errors or panics.
+	encV [16]byte
+
+	// tmp is a persistent [16]byte working buffer used during output generation.
+	// It holds the encrypted output for the final (partial) block in fillBlocks.
+	// This avoids repeated stack allocations and ensures maximum efficiency.
+	tmp [16]byte
+}
+
+// Read generates cryptographically secure random bytes and writes them into the provided slice b.
+//
+// This method implements the io.Reader interface for drbg, providing a FIPS 140-2 aligned
+// deterministic random bit generator using the AES-CTR-DRBG construction. Each call to Read
+// returns a unique cryptographically strong pseudo-random stream and is safe for concurrent use.
+//
+// Semantics and Implementation Details:
+//   - A snapshot of the current cryptographic state (key, block cipher, initial counter value) is loaded atomically.
+//   - The DRBG's internal counter (v) is protected by a mutex to guarantee atomic advancement and persistence
+//     between consecutive reads. This ensures that no two Read calls can produce overlapping output, and that
+//     the generator stream is continuous and non-repeating.
+//   - After generating the requested output, the advanced counter is persisted back to the DRBG instance.
+//   - If key rotation is enabled and the generated output exceeds the configured threshold, an asynchronous
+//     rekey operation is triggered. Rekeying swaps the cryptographic state atomically and resets the counter
+//     (under lock) to guarantee forward secrecy and FIPS alignment.
+//
+// Parameters:
+//   - b: Output buffer to be filled with cryptographically secure random bytes.
+//
+// Returns:
+//   - int: Number of bytes written (equal to len(b) unless b is empty).
+//   - error: Always nil under normal operation.
+func (d *drbg) Read(b []byte) (int, error) {
+	// Return immediately if the buffer is empty, as required by the io.Reader contract.
+	n := len(b)
+	if n == 0 {
+		return 0, nil
+	}
+
+	d.reseedIfForked()
+
+	// Prediction Resistance
+	if d.config.PredictionResistance {
+		if err := d.reseed(nil); err != nil {
+			return 0, fmt.Errorf("prediction resistance reseed failed: %w", err)
+		}
+	} else {
+		// Optional: Reseed if the configured interval has elapsed since the last reseed.
+		if d.config.ReseedInterval > 0 {
+			now := time.Now()
+			if now.Sub(d.lastReseedTime) >= d.config.ReseedInterval {
+				if err := d.reseed(nil); err != nil {
+					return 0, fmt.Errorf("interval reseed failed: %w", err)
+				}
+			}
+		}
+
+		// NIST-required: Reseed if the configured request count is exceeded.
+		if d.config.ReseedRequests > 0 && atomic.LoadUint64(&d.requests) >= d.config.ReseedRequests {
+			if err := d.reseed(nil); err != nil {
+				return 0, fmt.Errorf("request-count reseed failed: %w", err)
+			}
+		}
+	}
+
+	// Atomically load the current DRBG cryptographic state.
+	st := d.state.Load()
+
+	// Lock the counter mutex to guarantee exclusive access to the evolving counter.
+	d.vMu.Lock()
+
+	// Copy the current counter value to a local variable. This snapshot forms the basis
+	// of the unique keystream for this read operation.
+	copy(d.encV[:], d.v[:])
+
+	// Fill the output buffer using the current cryptographic state and the local counter,
+	// incrementing the counter as output is produced. All counter increments are reflected
+	// in the local variable.
+	d.fillBlocks(b, st, &d.encV)
+
+	// Persist the advanced counter back to the DRBG instance, ensuring subsequent reads
+	// continue the keystream seamlessly without overlap or repetition.
+	copy(d.v[:], d.encV[:])
+
+	// Unlock the mutex, allowing other callers to proceed.
+	d.vMu.Unlock()
+
+	// NIST-required: Increment the requests counter for this DRBG instance.
+	if !d.config.PredictionResistance {
+		atomic.AddUint64(&d.requests, 1)
+	}
+
+	// Key rotation logic: atomically update the usage counter and, if the output threshold is
+	// exceeded, trigger asynchronous rekeying in a background goroutine. Only one goroutine
+	// may perform rekeying at a time.
+	if d.config.EnableKeyRotation {
+		atomic.AddUint64(&d.usage, uint64(len(b)))
+		if atomic.LoadUint64(&d.usage) >= d.config.MaxBytesPerKey {
+			if atomic.CompareAndSwapUint32(&d.rekeying, 0, 1) {
+				go d.asyncRekey()
+			}
+		}
+	}
+
+	return n, nil
+}
+
+// ReadWithAdditionalInput fills the provided buffer with cryptographically secure random bytes,
+// optionally reseeding the DRBG instance with caller-provided additional input per NIST SP 800-90A.
+//
+// This method is intended for advanced use cases where explicit entropy injection or
+// per-call domain separation is required, as enabled by the NIST DRBG "additional input" feature.
+// If PredictionResistance is enabled, the DRBG reseeds from system entropy for every read and
+// ignores additionalInput as required by the standard. Otherwise, if additionalInput is non-nil,
+// the DRBG instance reseeds using a combination of system entropy, personalization, and the
+// supplied additionalInput before generating output.
+//
+// Semantics and Implementation Details:
+//   - If PredictionResistance is enabled, reseeds from fresh system entropy before generating output,
+//     ignoring additionalInput (NIST-compliant).
+//   - If PredictionResistance is not enabled and additionalInput is non-nil, reseeds using both entropy
+//     and the caller's input, per NIST specification.
+//   - Loads the current cryptographic state (AES key, block cipher, initial counter) atomically.
+//   - The DRBG's internal counter (v) is protected by a mutex to guarantee non-overlapping output across reads.
+//   - Output is generated using fillBlocks and the advanced counter value is persisted for continuity.
+//   - If key rotation is enabled and the usage threshold is exceeded, an asynchronous rekey is triggered.
+//
+// Parameters:
+//   - b []byte: Output buffer to be filled with cryptographically secure random bytes.
+//   - additionalInput []byte: Optional per-call entropy or context to inject during reseed. May be nil.
+//
+// Returns:
+//   - int: Number of bytes written (equal to len(b) unless b is empty).
+//   - error: Error if entropy acquisition, reseed, or output generation fails.
+//
+// Example:
+//
+//	n, err := drbg.ReadWithAdditionalInput(buf, []byte("request-entropy"))
+//	if err != nil {
+//	    // handle error
+//	}
+func (d *drbg) ReadWithAdditionalInput(b []byte, additionalInput []byte) (int, error) {
+	// Return immediately if the buffer is empty, as required by the io.Reader contract.
+	n := len(b)
+	if n == 0 {
+		return 0, nil
+	}
+
+	d.reseedIfForked()
+
+	// If PredictionResistance is enabled, always reseed from fresh entropy before output,
+	// ignoring any additional input per NIST SP 800-90A requirements.
+	if d.config.PredictionResistance {
+		if err := d.reseed(nil); err != nil {
+			return 0, fmt.Errorf("prediction resistance reseed failed: %w", err)
+		}
+	} else {
+		// Optional: Reseed if the configured interval has elapsed since the last reseed.
+		if d.config.ReseedInterval > 0 {
+			now := time.Now()
+			if now.Sub(d.lastReseedTime) >= d.config.ReseedInterval {
+				if err := d.reseed(nil); err != nil {
+					return 0, fmt.Errorf("interval reseed failed: %w", err)
+				}
+			}
+		}
+
+		// NIST-required: Reseed if the configured request count is exceeded.
+		if d.config.ReseedRequests > 0 && atomic.LoadUint64(&d.requests) >= d.config.ReseedRequests {
+			if err := d.reseed(nil); err != nil {
+				return 0, fmt.Errorf("request-count reseed failed: %w", err)
+			}
+		}
+
+		// If additionalInput is provided and prediction resistance is not enabled,
+		// reseed using both entropy and additional input for this output request.
+		if additionalInput != nil {
+			if err := d.reseed(additionalInput); err != nil {
+				return 0, fmt.Errorf("reseed with additional input failed: %w", err)
+			}
+		}
+	}
+
+	// Load the current cryptographic state (AES key, block cipher, initial counter) atomically.
+	st := d.state.Load()
+
+	// Lock the counter mutex to guarantee exclusive access to the evolving counter.
+	d.vMu.Lock()
+
+	// Copy the current counter value to a local variable for use in output generation.
+	copy(d.encV[:], d.v[:])
+
+	// Fill the output buffer using the current cryptographic state and the local counter,
+	// incrementing the counter as output is produced.
+	d.fillBlocks(b, st, &d.encV)
+
+	// Persist the advanced counter back to the DRBG instance, ensuring
+	// future reads continue the keystream seamlessly.
+	copy(d.v[:], d.encV[:])
+
+	// Unlock the mutex, allowing other callers to proceed.
+	d.vMu.Unlock()
+
+	// NIST-required: Increment the requests counter for this DRBG instance.
+	if !d.config.PredictionResistance {
+		atomic.AddUint64(&d.requests, 1)
+	}
+
+	// Key rotation logic: update the usage counter and, if the output threshold is
+	// exceeded, trigger asynchronous rekeying in a background goroutine.
+	if d.config.EnableKeyRotation {
+		atomic.AddUint64(&d.usage, uint64(n))
+		if atomic.LoadUint64(&d.usage) >= d.config.MaxBytesPerKey {
+			if atomic.CompareAndSwapUint32(&d.rekeying, 0, 1) {
+				go d.asyncRekey()
+			}
+		}
+	}
+
+	return n, nil
+}
+
+// Reseed injects new entropy and optional additional input, refreshing the DRBG instance's internal state.
+//
+// This method is compliant with NIST SP 800-90A and can be called at any time to force a rekey
+// and counter reset. The additionalInput parameter, if non-nil, is cryptographically combined
+// with system entropy and the configured personalization string to derive a new key and counter (V).
+//
+// Reseed is suitable for explicit entropy injection after external events, regulatory triggers,
+// or as a proactive measure to ensure stream independence and forward secrecy. Upon successful
+// reseed, all future outputs are derived from the new state.
+//
+// Parameters:
+//   - additionalInput []byte: Optional extra entropy or domain-separation input for this reseed operation.
+//     May be nil if not required.
+//
+// Returns:
+//   - error: Non-nil if entropy acquisition, cipher construction, or state replacement fails; nil on success.
+//
+// Example usage:
+//
+//	err := drbg.Reseed([]byte("device-boot-entropy"))
+//	if err != nil {
+//	    log.Fatalf("reseed failed: %v", err)
+//	}
+func (d *drbg) Reseed(additionalInput []byte) error {
+	// Reseed the DRBG instance using system entropy and any caller-provided additional input.
+	// The reseed function will cryptographically mix system entropy, personalization, and additionalInput,
+	// replacing the internal key, counter, and AES state atomically. If reseed fails, the previous state is retained.
+	return d.reseed(additionalInput)
+}
+
+// fillBlocks fills the byte slice `b` with cryptographically secure, deterministic random data
+// generated from the provided DRBG state and a caller-provided working counter.
+//
+// This method implements the core NIST SP 800-90A AES-CTR-DRBG output logic. It is concurrency safe
+// as it operates only on immutable state and caller-provided (session-local) counter. No DRBG struct
+// fields are mutated during block generation.
+//
+// Parameters:
+//   - b   []byte:      Output buffer to be filled with random bytes. Must be at least 1 byte in length.
+//   - st  *state:      Immutable snapshot of the DRBG key, block cipher, and initial counter (V).
+//   - v   *[16]byte:   Session-local working counter for this output operation. Advanced in place.
+//
+// Behavior:
+//   - Processes output in 16-byte (AES block size) chunks for maximal efficiency.
+//   - For each block, increments the session-local counter, encrypts it, and writes the result to output.
+//   - Supports two strategies:
+//   - UseZeroBuffer: Encrypted blocks are staged in a reusable buffer before being copied out (reducing allocations).
+//   - Fast path: Output is written directly into the caller's buffer except for a possible tail partial block,
+//     which uses the persistent drbg.tmp [16]byte buffer.
+//
+// Security:
+//   - Ensures every 16-byte block is generated with a unique counter value per NIST recommendations.
+//   - Never mutates DRBG fields or global internal state directly.
+//
+// Panics:
+//   - Never panics under normal operation. Will panic only if AES block size invariants are violated
+//     (should not be possible with validated configuration).
+func (d *drbg) fillBlocks(b []byte, st *state, v *[16]byte) {
+	// Return immediately if the buffer is empty, as required by the io.Reader contract.
+	n := len(b)
+	if n == 0 {
+		return
+	}
+
+	// Buffered output mode: stage keystream in reusable buffer to minimize allocations.
+	if d.config.UseZeroBuffer {
+		// Ensure the zero buffer is large enough; allocate if needed.
+		if cap(d.zero) < n {
+			d.zero = make([]byte, n)
+		}
+		d.zero = d.zero[:n] // Resize without reallocating if possible.
+
+		offset := 0
+		remaining := n
+		for remaining > 0 {
+			// Determine block size for this iteration (full or final partial block).
+			blockSize := 16
+			if remaining < 16 {
+				blockSize = remaining
+			}
+
+			// Advance the session-local counter as required by CTR mode (one block per keystream segment).
+			incV(v)
+
+			// Encrypt the incremented counter; write keystream into zero buffer.
+			st.block.Encrypt(d.zero[offset:offset+blockSize], v[:])
+
+			// Copy encrypted keystream to caller's buffer.
+			copy(b[offset:offset+blockSize], d.zero[offset:offset+blockSize])
+			offset += blockSize
+			remaining -= blockSize
+		}
+		return
+	}
+
+	// Fast path: direct write to output buffer, except for a final partial block.
+	offset := 0
+	for ; offset+16 <= n; offset += 16 {
+		incV(v)
+		st.block.Encrypt(b[offset:offset+16], v[:])
+	}
+
+	// Handle remaining tail (if output is not a multiple of 16 bytes).
+	if tail := n - offset; tail > 0 {
+		incV(v)
+		st.block.Encrypt(d.tmp[:], v[:])
+		copy(b[offset:], d.tmp[:tail])
+	}
+}
+
+// reseed refreshes the DRBG instance with new system entropy, personalization, and optional additional input.
+//
+// This function generates a new internal state (AES key, counter, and cipher block) using the provided DRBG
+// configuration and any additionalInput supplied by the caller. It atomically installs the new cryptographic state,
+// ensuring no overlap with previous keystream output. After reseed, both the byte usage counter and request count
+// are reset, and the reseed timestamp is updated to support interval/request-count-based reseed policies.
+//
+// Parameters:
+//   - additionalInput []byte: Optional, caller-supplied entropy or domain-separation material that is cryptographically
+//     combined with system entropy and personalization. May be nil for standard reseeds.
+//
+// Returns:
+//   - error: Non-nil if entropy acquisition or state initialization fails; nil on success.
+//
+// Concurrency Notes:
+//   - This method synchronizes counter updates using a mutex and uses atomic operations for usage/request counters.
+//   - If called concurrently, it is possible for closely timed reseeds to slightly race in updating the metadata fields;
+//     this does not impact cryptographic safety.
+func (d *drbg) reseed(additionalInput []byte) error {
+	// Generate a new DRBG state (key, counter, AES block) using system entropy,
+	// personalization string, and optional additional input.
+	newState, err := newDRBGState(d.config, additionalInput)
+	if err != nil {
+		return err
+	}
+
+	// Atomically install the new cryptographic state for this DRBG instance.
+	d.state.Store(newState)
+
+	// Acquire the counter mutex and update the working counter (v)
+	// to match the new state, ensuring unique, non-overlapping output.
+	d.vMu.Lock()
+	copy(d.v[:], newState.v[:])
+	d.vMu.Unlock()
+
+	// Reset the usage counter, guaranteeing fresh key usage tracking.
+	atomic.StoreUint64(&d.usage, 0)
+
+	// Update reseed tracking metadata.
+	d.lastReseedTime = time.Now()
+	atomic.StoreUint64(&d.requests, 0)
+
+	return nil
+}
+
+// newDRBGState generates a fresh, fully initialized DRBG state (AES key and counter) per NIST SP 800-90A.
+//
+// This function combines system entropy, the configured personalization string, and optional additional input
+// to derive a unique and unpredictable state. This process aligns with NIST recommendations for DRBG
+// instantiation and reseed, ensuring domain separation and strong security.
+//
+// The returned state encapsulates an AES block cipher initialized with the derived key, a copy of the key
+// material, and the initial 128-bit counter value (V). If entropy acquisition or cipher creation fails,
+// an error is returned and no state is produced.
+//
+// Parameters:
+//   - cfg *Config: The DRBG configuration, including key size, personalization, and related options.
+//   - additionalInput []byte: Optional per-call entropy or context to further randomize the state; may be nil.
+//
+// Returns:
+//   - *state: Newly derived DRBG state with fresh key, cipher, and counter.
+//   - error: Non-nil if entropy acquisition or cipher construction fails; nil on success.
+func newDRBGState(cfg *Config, additionalInput []byte) (*state, error) {
+	seedLen := cfg.KeySize + 16
+	seed := make([]byte, seedLen)
+
+	// Acquire fresh entropy from the operating system. This forms the basis of the DRBG seed material.
+	if _, err := io.ReadFull(rand.Reader, seed); err != nil {
+		return nil, err
+	}
+
+	// Incorporate the personalization string, if provided, by XOR-ing it into the seed for domain separation.
+	// Mix in any caller-supplied additional input by XOR-ing it into the seed, further randomizing the state.
+	mixSeed(seed, cfg.Personalization, additionalInput)
+
+	// Split the seed buffer into an AES key (of the configured size) and a 128-bit counter (V).
+	var key [32]byte
+	copy(key[:], seed[:cfg.KeySize])
+	var v [16]byte
+	copy(v[:], seed[cfg.KeySize:])
+
+	// Initialize the AES block cipher using the derived key. Return an error if cipher creation fails.
+	block, err := aes.NewCipher(key[:cfg.KeySize])
+	if err != nil {
+		return nil, err
+	}
+
+	// Construct and return the new DRBG state, encapsulating the cipher, key, and counter.
+	return &state{
+		block: block,
+		key:   key,
+		v:     v,
+	}, nil
+}
+
+// newDRBG creates and returns a new, fully initialized deterministic random bit generator (DRBG) instance.
+//
+// This function constructs a FIPS 140-2 aligned AES-CTR-DRBG instance, securely seeded from operating system entropy.
+// Initialization steps are as follows:
+//  1. Acquire a seed consisting of (key size + 16) bytes of cryptographically strong random data.
+//  2. Optionally XOR in a personalization string for domain separation, as required by SP 800-90A.
+//  3. Derive the AES key and initial counter (V) from the seed.
+//  4. Construct the AES block cipher with the derived key, and fail if the cipher cannot be created.
+//  5. Optionally allocate a reusable zero buffer if requested in configuration.
+//  6. Store the resulting cryptographic state atomically and initialize the working counter (v) from this state.
+//
+// If entropy acquisition or cipher construction fails, an error is returned and the DRBG is not created.
+//
+// Parameters:
+//   - cfg: *Config — pointer to the DRBG configuration (must be non-nil)
+//
+// Returns:
+//   - *drbg: newly initialized DRBG instance, ready for use
+//   - error: non-nil if any initialization step fails (entropy, cipher, or config error)
+func newDRBG(cfg *Config) (*drbg, error) {
+	seedLen := cfg.KeySize + 16
+
+	// Allocate a buffer for the full seed: key + 128-bit counter.
+	seed := make([]byte, seedLen)
+
+	// Read entropy from the operating system. Fail if not available.
+	if _, err := io.ReadFull(rand.Reader, seed); err != nil {
+		return nil, err
+	}
+
+	// XOR in personalization string (if any) for domain separation.
+	mixSeed(seed, cfg.Personalization, nil)
+
+	// Derive the AES key and the initial counter (V) from the seed.
+	var key [32]byte
+	copy(key[:], seed[:cfg.KeySize])
+	var v [16]byte
+	copy(v[:], seed[cfg.KeySize:])
+
+	// Construct the AES block cipher using the derived key.
+	block, err := aes.NewCipher(key[:cfg.KeySize])
+	if err != nil {
+		return nil, err
+	}
+
+	// Optionally preallocate the zero buffer for buffer-reuse mode.
+	var zero []byte
+	if cfg.UseZeroBuffer && cfg.DefaultBufferSize > 0 {
+		zero = make([]byte, cfg.DefaultBufferSize)
+	}
+
+	// Store the immutable cryptographic state atomically.
+	st := &state{
+		block: block,
+		key:   key,
+		v:     v,
+	}
+	d := &drbg{
+		config:   cfg,
+		zero:     zero,
+		usage:    0,
+		rekeying: 0,
+		pid:      os.Getpid(),
+	}
+	d.state.Store(st)
+
+	// Initialize the working counter (v) from the state, guaranteeing unique output on first use.
+	copy(d.v[:], v[:])
+
+	return d, nil
+}
+
+// mixSeed incorporates the personalization string and additional input into the DRBG seed.
+//
+// This function XORs both the personalization string (for domain separation) and any
+// caller-provided additional input (for added entropy or context) into the given seed buffer,
+// wrapping both as needed if their lengths exceed the seed length. This process is per NIST SP 800-90A.
+//
+// Parameters:
+//   - seed:              The entropy seed buffer to be mixed into (usually key+V).
+//   - personalization:   Optional domain-separation string; XOR-ed into the seed.
+//   - additionalInput:   Optional caller-supplied input; further XOR-ed into the seed.
+//
+// Each byte of personalization and additionalInput is XOR-ed into seed at the corresponding
+// index, wrapping with modulo if necessary.
+//
+// Example usage:
+//
+//	mixSeed(seed, cfg.Personalization, additionalInput)
+func mixSeed(seed []byte, personalization, additionalInput []byte) {
+	// Incorporate the personalization string by XOR-ing it into the seed
+	// to achieve domain separation. This ensures that DRBG instances with
+	// different personalization values generate independent streams.
+	for i := range personalization {
+		seed[i%len(seed)] ^= personalization[i]
+	}
+
+	// Mix in any caller-supplied additional input (such as explicit entropy)
+	// by XOR-ing it into the seed. This further randomizes the DRBG state,
+	// enhancing uniqueness or context-sensitivity per NIST guidelines.
+	for i := range additionalInput {
+		seed[i%len(seed)] ^= additionalInput[i]
+	}
+}
+
+// asyncRekey performs an asynchronous, non-blocking reseed and key rotation for the DRBG instance.
+//
+// This function is launched in a background goroutine when the generated output exceeds the configured threshold
+// (MaxBytesPerKey). It attempts to generate new entropy, derive a new key and counter, and atomically install a
+// new DRBG state. The working counter (v) is reset to the new initial value under lock. If all attempts to reseed
+// fail, the existing cryptographic state is left unchanged, and the generator continues operating.
+//
+// Steps:
+//  1. Attempt up to MaxRekeyAttempts reseed/rotate cycles, with exponential backoff (bounded by MaxRekeyBackoff).
+//  2. For each attempt:
+//     - Acquire a fresh random seed and optionally apply personalization.
+//     - Derive a new key and counter (V), and construct a new AES cipher.
+//     - On success, atomically store the new state, reset the usage counter, and set the working counter (v).
+//  3. Always clear the rekeying flag before returning (even on panic or error), so future rekeys can proceed.
+//
+// Parameters: None (method receiver only).
+func (d *drbg) asyncRekey() {
+	// Always clear the rekeying flag on exit.
+	defer atomic.StoreUint32(&d.rekeying, 0)
+
+	base := d.config.RekeyBackoff
+	maxBackoff := d.config.MaxRekeyBackoff
+	if maxBackoff == 0 {
+		maxBackoff = defaultMaxBackoff
+	}
+
+	// Attempt to reseed and rekey up to MaxRekeyAttempts times.
+	for i := 0; i < d.config.MaxRekeyAttempts; i++ {
+		// Obtain new entropy for key and counter (V).
+		seedLen := d.config.KeySize + 16 // Key size plus 128-bit counter
+		seed := make([]byte, seedLen)
+		if _, err := io.ReadFull(rand.Reader, seed); err == nil {
+			// Apply personalization string, if set, by XORing into the seed.
+			mixSeed(seed, d.config.Personalization, nil)
+
+			// Construct the new AES key and counter (V) from the seed buffer.
+			var key [32]byte
+			copy(key[:], seed[:d.config.KeySize])
+			var v [16]byte
+			copy(v[:], seed[d.config.KeySize:])
+			block, err := aes.NewCipher(key[:d.config.KeySize])
+			if err == nil {
+				// Store new cryptographic state atomically.
+				newState := &state{
+					block: block,
+					key:   key,
+					v:     v,
+				}
+				d.state.Store(newState)
+				atomic.StoreUint64(&d.usage, 0)
+
+				// Reset the working counter (v) under mutex lock to ensure no overlap.
+				d.vMu.Lock()
+				copy(d.v[:], v[:])
+				d.vMu.Unlock()
+				return // Rekey complete.
+			}
+
+			// (If cipher construction fails, fall through and retry after backoff.)
+		}
+
+		// Wait with exponential backoff before retrying.
+		time.Sleep(base)
+		base *= 2
+		if base > maxBackoff {
+			base = maxBackoff
+		}
+	}
+	// If all retries fail, generator continues with prior state.
+}
+
+// incV increments the DRBG counter (V) in big-endian order, rolling over as needed.
+//
+// The counter (V) is treated as a 128-bit unsigned integer in big-endian representation.
+// Each call increments the counter by one, wrapping as appropriate. This function
+// is used for advancing the DRBG keystream per SP 800-90A section on counter mode.
+// Not concurrency safe; caller must synchronize if used from multiple goroutines.
+//
+// Parameters:
+//   - v: pointer to a 16-byte array ([16]byte), representing the current counter value.
+//
+// Returns: None (modifies v in place).
+func incV(v *[16]byte) {
+	// Start from the least significant byte (rightmost, index 15), incrementing with carry.
+	for i := 15; i >= 0; i-- {
+		v[i]++
+		if v[i] != 0 {
+			break // No further carry needed; stop.
+		}
+	}
+}

--- a/vendor/github.com/sixafter/aes-ctr-drbg/config.go
+++ b/vendor/github.com/sixafter/aes-ctr-drbg/config.go
@@ -1,0 +1,390 @@
+// Copyright (c) 2024-2025 Six After, Inc
+//
+// This source code is licensed under the Apache 2.0 License found in the
+// LICENSE file in the root directory of this source tree.
+//
+// Package ctrdrbg provides configuration types and functional options for the
+// AES-CTR-DRBG (Deterministic Random Bit Generator) cryptographically secure pseudo-random number generator.
+//
+// The Config type exposes tunable parameters for the DRBG pool, instance management, and
+// cryptographic behavior. These options support both security and operational flexibility.
+
+package ctrdrbg
+
+import (
+	"runtime"
+	"time"
+)
+
+// KeySize represents the valid AES key lengths supported by AES-CTR-DRBG.
+//
+// It enforces compile-time type safety for AES key selection and helps
+// prevent accidental misuse of invalid key lengths. Only KeySize128, KeySize192, and KeySize256
+// are permitted values for cryptographic configuration.
+//
+// Usage:
+//
+//	// Configure for AES-256 (32 bytes)
+//	cfg := ctrdrbg.DefaultConfig()
+//	cfg.KeySize = ctrdrbg.KeySize256
+type KeySize int
+
+const (
+	// KeySize128 specifies AES-128 (16-byte key).
+	KeySize128 KeySize = 16
+
+	// KeySize192 specifies AES-192 (24-byte key).
+	KeySize192 KeySize = 24
+
+	// KeySize256 specifies AES-256 (32-byte key).
+	KeySize256 KeySize = 32
+)
+
+// Config defines the tunable parameters for AES-CTR-DRBG instances and the DRBG pool.
+//
+// It supports fine-grained control over key size, key rotation, rekeying policies,
+// backoff behavior, and instance personalization, enabling security-focused customization for a variety of use cases.
+//
+// Fields:
+//   - KeySize: AES key length (16, 24, or 32 bytes for AES-128, -192, or -256).
+//   - MaxBytesPerKey: Max output per key before automatic rekeying (forward secrecy).
+//   - MaxInitRetries: Number of retries for DRBG pool initialization before panic.
+//   - MaxRekeyAttempts: Max number of rekey attempts before giving up.
+//   - MaxRekeyBackoff: Maximum backoff duration for exponential rekey retries.
+//   - RekeyBackoff: Initial backoff for rekey attempts.
+//   - EnableKeyRotation: Whether to enable automatic key rotation (default: true).
+//   - Personalization: Optional per-instance byte string for domain separation.
+type Config struct {
+	// Personalization provides a per-instance personalization string, which is XOR-ed into the
+	// DRBG’s initial seed to support domain separation or unique generator state.
+	//
+	// Purpose:
+	// - Ensures cryptographic independence of DRBG streams even if seeds or environments overlap.
+	// - Enables strong domain separation by context (service, user, tenant, device, etc.).
+	//
+	// Example:
+	//   To ensure that two DRBGs used for "auth" and "billing" services are cryptographically isolated,
+	//   pass unique byte strings (e.g., []byte("auth-service-v1") and []byte("billing-service-v1"))
+	//   via WithPersonalization to their respective NewReader calls.
+	//
+	//   r1, _ := ctrdrbg.NewReader(ctrdrbg.WithPersonalization([]byte("auth-service-v1")))
+	//   r2, _ := ctrdrbg.NewReader(ctrdrbg.WithPersonalization([]byte("billing-service-v1")))
+	//
+	// When unset (nil), no personalization is applied.
+	Personalization []byte
+
+	// RekeyBackoff is the initial delay before retrying a failed rekey operation.
+	//
+	// Exponential backoff doubles the delay for each failure up to MaxRekeyBackoff.
+	// If set to zero, the default is 100 milliseconds.
+	RekeyBackoff time.Duration
+
+	// MaxRekeyBackoff specifies the maximum duration (clamped) for exponential backoff during rekey attempts.
+	//
+	// If set to zero, a default value of 2 seconds is used.
+	MaxRekeyBackoff time.Duration
+
+	// ReseedInterval is the minimum time duration between automatic reseeds from system entropy.
+	//
+	// When set (non-zero), the DRBG will automatically reseed after this interval elapses,
+	// regardless of key usage or bytes generated. Zero disables interval-based reseeding.
+	ReseedInterval time.Duration
+
+	// MaxBytesPerKey is the maximum number of bytes generated per key before triggering automatic rekeying.
+	//
+	// Rekeying after a fixed output window enforces forward secrecy and mitigates key exposure risk.
+	// If set to zero, a default value of 1 GiB (1 << 30) is used.
+	MaxBytesPerKey uint64
+
+	// ReseedRequests is the maximum number of output requests (calls to Read) allowed before forcing a reseed.
+	//
+	// When set (non-zero), the DRBG will automatically reseed after this many Read or ReadWithAdditionalInput calls.
+	// Zero disables reseed-on-request-count.
+	ReseedRequests uint64
+
+	// ForkDetectionInterval controls how often fork detection is performed.
+	//
+	// If 0 (default), fork detection runs on every output request (max safety, fully compliant).
+	// If >0, fork detection is performed once every N output requests (advanced tuning; reduces overhead
+	// at the cost of a negligible window of risk).
+	//
+	// WARNING: Setting this above zero is NOT recommended for compliance-sensitive environments.
+	ForkDetectionInterval uint64
+
+	// KeySize specifies the AES key length to use for this DRBG instance.
+	//
+	// Acceptable values:
+	//   - KeySize128 (16 bytes, AES-128)
+	//   - KeySize192 (24 bytes, AES-192)
+	//   - KeySize256 (32 bytes, AES-256)
+	//
+	// Default: KeySize256 (AES-256, 32 bytes).
+	KeySize KeySize
+
+	// MaxRekeyAttempts specifies the number of attempts to perform asynchronous rekeying.
+	//
+	// On failure, exponential backoff is used between attempts. If zero, a default of 5 is used.
+	MaxRekeyAttempts int
+
+	// MaxInitRetries is the maximum number of attempts to initialize a DRBG pool entry before giving up and panicking.
+	//
+	// Initialization can fail if system entropy is exhausted or if the cryptographic backend is unavailable.
+	// If set to zero, a default of 3 is used.
+	MaxInitRetries int
+
+	// DefaultBufferSize specifies the initial capacity of the internal buffer used for zero-filled output operations.
+	//
+	// Only relevant if UseZeroBuffer is true. If zero, no preallocation is performed.
+	DefaultBufferSize int
+
+	// Shards controls the number of pools (shards) to use for parallelism.
+	//
+	// If zero, defaults to runtime.GOMAXPROCS(0).
+	// Increase this to improve throughput under high concurrency.
+	Shards int
+
+	// EnableKeyRotation controls whether instances automatically rotate their key after MaxBytesPerKey output.
+	//
+	// Automatic key rotation provides forward secrecy and aligns with cryptographic best practices.
+	// Defaults to true.
+	EnableKeyRotation bool
+
+	// PredictionResistance enables NIST SP 800-90A prediction resistance mode for this DRBG instance.
+	//
+	// When set to true, the DRBG will automatically reseed from fresh system entropy before every
+	// output generation (each call to Read or ReadWithAdditionalInput), as required for compliance
+	// with "prediction resistance" in Section 9.3 of SP 800-90A. This defeats state compromise
+	// extension and protects against backtracking even if the DRBG's internal state is exposed.
+	//
+	// When enabled:
+	//   - All additionalInput passed to ReadWithAdditionalInput or Reseed is ignored.
+	//   - Reseeding is performed before each output operation, guaranteeing that every call mixes in
+	//     new system entropy and cannot be predicted from previous outputs, even if internal state is known.
+	//
+	// When false (default), the DRBG operates in the normal mode, and reseeding occurs only at
+	// initialization, on demand, or after MaxBytesPerKey is exceeded (if key rotation is enabled).
+	//
+	// Set via Config directly, or by using the WithPredictionResistance functional option.
+	//
+	// Security rationale:
+	//   - Enables maximal resilience against state compromise and forward/backward prediction attacks.
+	//   - May increase system entropy usage and affect throughput in high-rate scenarios.
+	PredictionResistance bool
+
+	// UseZeroBuffer determines whether each Read operation uses a zero-filled buffer for AES-CTR output.
+	//
+	// If true, Read uses an internal buffer of zeroes for XOR operations (if the underlying implementation requires).
+	// If false, output may be generated in place, which is typically faster and allocation-free.
+	// Defaults to false.
+	UseZeroBuffer bool
+}
+
+// Default configuration constants for AES-CTR-DRBG.
+const (
+	// Default max bytes per key (1 GiB)
+	defaultMaxBytes = 1 << 30
+
+	// Default max initialization retries
+	defaultInitRetries = 3
+
+	// Default max rekey attempts
+	defaultRekeyRetries = 5
+
+	// Default max backoff for rekey (2 seconds)
+	defaultMaxBackoff = 2 * time.Second
+
+	// Default initial rekey backoff (100 ms)
+	defaultRekeyBackoff = 100 * time.Millisecond
+)
+
+// DefaultConfig returns a Config struct populated with production-safe, NIST SP 800-90A Section 10.2.1-aligned defaults.
+//
+// This function provides a robust baseline configuration for AES-CTR-DRBG instances, suitable for general-purpose
+// cryptographic use and high-concurrency workloads. All parameters are selected to ensure strong security, compliance
+// with FIPS 140-2 and NIST SP 800-90A requirements, and operational reliability under diverse system conditions.
+//
+// The returned configuration enables fork-safety (via PID tracking), supports domain separation via personalization,
+// and is compatible with Go's FIPS-140 mode (GODEBUG=fips140=on).
+//
+// Defaults:
+//   - KeySize:            32 bytes (AES-256, recommended by NIST for most use cases)
+//   - MaxBytesPerKey:     1 GiB (1 << 30); triggers key rotation for forward secrecy
+//   - MaxInitRetries:     3 attempts to initialize each DRBG pool entry
+//   - MaxRekeyAttempts:   5 attempts per automatic key rotation
+//   - MaxRekeyBackoff:    2 seconds (maximum exponential backoff between failed rekey attempts)
+//   - RekeyBackoff:       100 milliseconds (initial backoff for rekey attempts)
+//   - EnableKeyRotation:  false (key rotation is disabled by default—**set to true for forward secrecy**)
+//   - Personalization:    nil (no domain separation unless set by the caller)
+//   - UseZeroBuffer:      false (random output generated directly into caller's buffer)
+//   - DefaultBufferSize:  0 (no preallocation of zero-filled buffers)
+//   - Shards:             runtime.GOMAXPROCS(0) (number of internal DRBG pools matches available CPUs)
+//   - PredictionResistance: false (prediction resistance is disabled; enable only if required by policy)
+//   - ForkDetectionInterval: 0 (fork detection performed on every output request for maximum safety)
+//
+// NIST Reference:
+//   - See NIST SP 800-90A, Section 10.2.1 (CTR DRBG) for cryptographic construction details.
+//
+// Example usage:
+//
+//	cfg := ctrdrbg.DefaultConfig()
+func DefaultConfig() Config {
+	return Config{
+		KeySize:               KeySize256,
+		MaxBytesPerKey:        defaultMaxBytes,
+		MaxInitRetries:        defaultInitRetries,
+		MaxRekeyAttempts:      defaultRekeyRetries,
+		MaxRekeyBackoff:       defaultMaxBackoff,
+		RekeyBackoff:          defaultRekeyBackoff,
+		EnableKeyRotation:     false,
+		Personalization:       nil,
+		UseZeroBuffer:         false,
+		DefaultBufferSize:     0,
+		Shards:                runtime.GOMAXPROCS(0),
+		PredictionResistance:  false,
+		ForkDetectionInterval: 0,
+	}
+}
+
+// Option defines a functional option for customizing a Config.
+//
+// Use Option values with NewReader or other constructors that accept variadic options.
+//
+// Example:
+//
+//	r, err := ctrdrbg.NewReader(
+//	    ctrdrbg.WithKeySize(ctrdrbg.KeySize256),
+//	    ctrdrbg.WithPersonalization([]byte("service-A")),
+//	)
+type Option func(*Config)
+
+// WithKeySize returns an Option that sets the AES key size for this DRBG instance.
+//
+// Acceptable values are KeySize128 (16 bytes), KeySize192 (24 bytes), or KeySize256 (32 bytes).
+// Any other value will cause NewReader to fail with an error at construction time.
+func WithKeySize(k KeySize) Option { return func(cfg *Config) { cfg.KeySize = k } }
+
+// WithMaxBytesPerKey returns an Option that sets the maximum number of bytes output per key before rekeying.
+//
+// This enforces a forward secrecy window: after MaxBytesPerKey random bytes are generated,
+// the DRBG automatically performs a rekey operation (if key rotation is enabled) to derive a new key
+// from fresh entropy. Lower this value to increase key rotation frequency for higher assurance.
+func WithMaxBytesPerKey(n uint64) Option { return func(cfg *Config) { cfg.MaxBytesPerKey = n } }
+
+// WithMaxInitRetries returns an Option that sets the maximum number of attempts to initialize a DRBG instance
+// in the pool before failing.
+//
+// Increase this value if your system occasionally fails to gather entropy or encounters transient cryptographic errors
+// at startup.
+func WithMaxInitRetries(n int) Option { return func(cfg *Config) { cfg.MaxInitRetries = n } }
+
+// WithMaxRekeyAttempts returns an Option that sets the maximum number of attempts allowed for
+// asynchronous key rotation (rekey) in the DRBG.
+//
+// If all rekey attempts fail, the DRBG continues using the previous state. Exponential backoff is applied
+// between attempts (see WithMaxRekeyBackoff and WithRekeyBackoff).
+func WithMaxRekeyAttempts(n int) Option { return func(cfg *Config) { cfg.MaxRekeyAttempts = n } }
+
+// WithMaxRekeyBackoff returns an Option that sets the maximum duration for exponential backoff between
+// failed rekey attempts.
+//
+// When a rekey attempt fails, the DRBG waits with exponentially increasing intervals, up to this maximum duration,
+// before retrying. If set to zero, a default (2s) is used.
+func WithMaxRekeyBackoff(d time.Duration) Option {
+	return func(cfg *Config) { cfg.MaxRekeyBackoff = d }
+}
+
+// WithRekeyBackoff returns an Option that sets the initial backoff duration before retrying a failed rekey operation.
+//
+// The first failure sleeps this duration, doubling for each subsequent failure, up to MaxRekeyBackoff.
+func WithRekeyBackoff(d time.Duration) Option {
+	return func(cfg *Config) { cfg.RekeyBackoff = d }
+}
+
+// WithEnableKeyRotation returns an Option that enables or disables automatic key rotation in the DRBG.
+//
+// When enabled (true), the DRBG automatically performs a key rotation after MaxBytesPerKey bytes are output.
+// When disabled (false), key rotation is suppressed and the DRBG uses the original key indefinitely.
+//
+// For most use cases, leave this enabled for forward secrecy and NIST alignment. Disable only for
+// compliance testing or special-purpose scenarios.
+func WithEnableKeyRotation(enable bool) Option {
+	return func(cfg *Config) { cfg.EnableKeyRotation = enable }
+}
+
+// WithPersonalization returns an Option that sets a per-instance personalization string
+// to be XOR-ed into the DRBG's seed for domain separation.
+//
+// Personalization ensures that two DRBG instances constructed with the same system seed but different
+// personalization values produce independent random streams, even if instantiated simultaneously.
+//
+// Use for tenant, application, service, or hardware isolation as required by your security model.
+func WithPersonalization(p []byte) Option {
+	return func(cfg *Config) { cfg.Personalization = p }
+}
+
+// WithUseZeroBuffer returns an Option that enables or disables use of a zero-filled buffer
+// for output in the DRBG.
+//
+// If enabled (true), the DRBG allocates and maintains a reusable zero-filled buffer
+// for CTR-mode output. If disabled (false), output is written directly to the destination buffer.
+//
+// This option primarily affects performance tuning; it does not impact cryptographic security.
+func WithUseZeroBuffer(enable bool) Option {
+	return func(cfg *Config) { cfg.UseZeroBuffer = enable }
+}
+
+// WithDefaultBufferSize returns an Option that sets the initial capacity of the internal zero buffer
+// used for output if UseZeroBuffer is enabled.
+//
+// This can reduce allocations when large or repeated output requests are expected.
+func WithDefaultBufferSize(n int) Option {
+	return func(cfg *Config) { cfg.DefaultBufferSize = n }
+}
+
+// WithShards returns an Option that sets the number of internal pool shards for the DRBG.
+//
+// Sharding improves parallelism and reduces contention under high concurrency, at the cost of increased memory use.
+// If n <= 0, the shard count defaults to runtime.GOMAXPROCS(0).
+func WithShards(n int) Option {
+	return func(cfg *Config) {
+		if n <= 0 {
+			n = runtime.GOMAXPROCS(0)
+		}
+		cfg.Shards = n
+	}
+}
+
+// WithPredictionResistance returns an Option that enables or disables NIST SP 800-90A prediction resistance mode.
+//
+// When enabled (true), the DRBG reseeds from fresh system entropy before every output generation,
+// making the output stream robust against state compromise extension and backtracking attacks.
+//
+// This mode increases system entropy usage and can impact performance in high-throughput scenarios.
+// Use only when required by compliance or application policy.
+func WithPredictionResistance(enable bool) Option {
+	return func(cfg *Config) { cfg.PredictionResistance = enable }
+}
+
+// WithReseedInterval returns an Option that sets the minimum duration between automatic reseeds from system entropy.
+//
+// When set to a non-zero value, the DRBG will reseed after this interval elapses, even if no key rotation
+// or manual reseed occurs. Set to zero to disable interval-based reseeding.
+func WithReseedInterval(d time.Duration) Option {
+	return func(cfg *Config) { cfg.ReseedInterval = d }
+}
+
+// WithReseedRequests returns an Option that sets the maximum number of output requests (calls to Read)
+// allowed before forcing an automatic reseed from system entropy.
+//
+// Set to zero to disable reseed-on-request-count behavior.
+func WithReseedRequests(n uint64) Option {
+	return func(cfg *Config) { cfg.ReseedRequests = n }
+}
+
+// WithForkDetectionInterval sets the number of output requests between fork detection checks.
+//
+// WARNING: Setting this above zero introduces a window where a fork may not be detected immediately.
+// Only set for performance-tuned applications that do NOT require strict compliance!
+func WithForkDetectionInterval(n uint64) Option {
+	return func(cfg *Config) { cfg.ForkDetectionInterval = n }
+}

--- a/vendor/github.com/sixafter/aes-ctr-drbg/cosign.pub
+++ b/vendor/github.com/sixafter/aes-ctr-drbg/cosign.pub
@@ -1,0 +1,4 @@
+-----BEGIN PUBLIC KEY-----
+MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEL8sfoH8pfy1iB9LLLKGLt3pxsYSV
+PbXKokUSmGgfk5e1cIyDKkwDso6pR+yoAuaf6D7wMlICkDhAQJxAaqh/vg==
+-----END PUBLIC KEY-----

--- a/vendor/github.com/sixafter/aes-ctr-drbg/drbg_fork.go
+++ b/vendor/github.com/sixafter/aes-ctr-drbg/drbg_fork.go
@@ -1,0 +1,55 @@
+// Copyright (c) 2024-2025 Six After, Inc
+//
+// This source code is licensed under the Apache 2.0 License found in the
+// LICENSE file in the root directory of this source tree.
+
+//go:build !windows
+
+package ctrdrbg
+
+import (
+	"os"
+	"sync/atomic"
+)
+
+// reseedIfForked performs fork detection and conditional reseeding according to the configured interval.
+//
+// This method ensures the DRBG instance reseeds its state in the event of a process fork (e.g., fork(2)).
+// The fork detection check is performed on every output request if ForkDetectionInterval is zero (the default, safest setting).
+// If ForkDetectionInterval is set to a nonzero value N, the fork detection check is only performed every N output requests.
+//
+// Semantics and Behavior:
+//   - Increments the output request counter atomically.
+//   - If ForkDetectionInterval is zero, always checks for fork (fully compliant, safest).
+//   - If ForkDetectionInterval is N>0, checks only every Nth output request (performance-tuned, non-compliant).
+//   - If a fork is detected (current PID != cached PID), reseeds the DRBG instance and updates the cached PID.
+//
+// Security Rationale:
+//   - Forking a process duplicates DRBG state. If not reseeded, parent and child may produce identical output, violating forward secrecy.
+//   - Interval-based fork detection reduces syscall overhead but introduces a risk window; do not use in regulated/compliance-critical environments.
+//
+// Usage:
+//   - Call at the beginning of every output-generating operation (e.g., Read, ReadWithAdditionalInput).
+func (d *drbg) reseedIfForked() {
+	interval := d.config.ForkDetectionInterval
+	if interval == 0 {
+		// Default: always check for fork
+		current := os.Getpid()
+		if current != d.pid {
+			_ = d.Reseed(nil) // Best-effort reseed
+			d.pid = current
+		}
+		return
+	}
+
+	// Only check every Nth request
+	n := atomic.AddUint64(&d.requests, 1)
+	if n%interval != 0 {
+		return // Not time to check yet
+	}
+	current := os.Getpid()
+	if current != d.pid {
+		_ = d.Reseed(nil) // Best-effort reseed
+		d.pid = current
+	}
+}

--- a/vendor/github.com/sixafter/aes-ctr-drbg/drbg_fork_windows.go
+++ b/vendor/github.com/sixafter/aes-ctr-drbg/drbg_fork_windows.go
@@ -1,0 +1,32 @@
+// Copyright (c) 2024-2025 Six After, Inc
+//
+// This source code is licensed under the Apache 2.0 License found in the
+// LICENSE file in the root directory of this source tree.
+
+//go:build windows
+
+package ctrdrbg
+
+// reseedIfForked is a platform-specific no-op on Windows.
+//
+// On Windows, the concept of process forking (as in fork(2) on Unix-like systems) does not exist.
+// Consequently, the risk of duplicated DRBG state due to process fork is not present, and no
+// fork-detection or reseeding logic is required.
+//
+// This stub function satisfies the interface for fork detection and is used in place of the
+// fork-aware implementation found on other platforms. It introduces zero runtime overhead.
+//
+// Semantics and Behavior:
+//   - Does nothing on Windows; safe to call at any point.
+//   - Present solely for cross-platform compatibility.
+//
+// Security Rationale:
+//   - There is no process-level forking on Windows.
+//   - No action is required to preserve DRBG stream uniqueness in this environment.
+//
+// Usage Notes:
+//   - Automatically included via Go build tags for Windows targets (`//go:build windows`).
+//   - All fork-related security logic is compiled out for this platform.
+func (d *drbg) reseedIfForked() {
+	// No-op: Windows does not implement fork(), so fork detection is unnecessary.
+}

--- a/vendor/github.com/sixafter/aes-ctr-drbg/sonar-project.properties
+++ b/vendor/github.com/sixafter/aes-ctr-drbg/sonar-project.properties
@@ -1,0 +1,32 @@
+# =====================================================
+# Standard Properties
+# =====================================================
+# Ref: https://docs.sonarqube.org/latest/analysis/analysis-parameters/
+sonar.organization=six-after
+sonar.projectKey=six-after_aes-ctr-drbg
+
+sonar.verbose=true
+sonar.sources=.
+sonar.exclusions=**/*_test.go,**/vendor/**,docs/**,scripts/**
+
+sonar.tests=.
+sonar.test.inclusions=**/*_test.go
+sonar.test.exclusions=**/vendor/**,docs/**,scripts/**
+
+# =====================================================
+# Project Configuration
+# =====================================================
+
+sonar.links.homepage=https://github.com/sixafter/aes-ctr-drbg
+sonar.links.ci=https://github.com/sixafter/aes-ctr-drbg
+sonar.links.scm=https://github.com/sixafter/aes-ctr-drbg
+sonar.links.issue=https://github.com/sixafter/aes-ctr-drbg
+
+# =====================================================
+#   Properties specific to Go
+# =====================================================
+
+#sonar.go.govet.reportPaths=govet-report.out
+#sonar.go.golint.reportPaths=golint-report.out
+sonar.go.tests.reportPaths=coverage.json
+sonar.go.coverage.reportPaths=coverage.out

--- a/vendor/github.com/sixafter/nanoid/config.go
+++ b/vendor/github.com/sixafter/nanoid/config.go
@@ -6,11 +6,15 @@
 package nanoid
 
 import (
+	"crypto/fips140"
 	"io"
 	"math"
 	"math/bits"
 	"unicode"
 	"unicode/utf8"
+
+	"github.com/sixafter/aes-ctr-drbg"
+	"github.com/sixafter/prng-chacha"
 )
 
 // ConfigOptions holds the configurable options for the Interface.
@@ -200,6 +204,35 @@ func WithRandReader(reader io.Reader) Option {
 func WithLengthHint(hint uint16) Option {
 	return func(c *ConfigOptions) {
 		c.LengthHint = hint
+	}
+}
+
+// WithAutoRandReader selects a secure random source at runtime based on
+// the system’s FIPS (Federal Information Processing Standards) compliance mode.
+// If FIPS 140-3 mode is enabled, it uses an AES-CTR-DRBG implementation;
+// otherwise, it defaults to a ChaCha20-based DRBG.
+//
+// This allows the Nano ID generator to comply with cryptographic requirements
+// in regulated environments while defaulting to a high-performance CSPRNG
+// (ChaCha20) for general use.
+//
+// Internally, it relies on the Go standard library’s runtime flag detection
+// via crypto/fips140.Enabled(), which reflects the value of the
+// environment variable GODEBUG=fips140=on|only.
+//
+// Returns:
+//   - Option: A configuration option that sets the RandReader field of ConfigOptions.
+//
+// Usage Example:
+//
+//	generator, err := nanoid.NewGenerator(nanoid.WithAutoRandReader())
+func WithAutoRandReader() Option {
+	return func(c *ConfigOptions) {
+		if fips140.Enabled() {
+			c.RandReader = ctrdrbg.Reader
+		} else {
+			c.RandReader = prng.Reader
+		}
 	}
 }
 

--- a/vendor/github.com/sixafter/nanoid/nanoid.go
+++ b/vendor/github.com/sixafter/nanoid/nanoid.go
@@ -64,7 +64,7 @@ const (
 
 func init() {
 	var err error
-	Generator, err = NewGenerator()
+	Generator, err = NewGenerator(WithAutoRandReader())
 	if err != nil {
 		panic(fmt.Sprintf("failed to initialize Generator: %v", err))
 	}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -10,7 +10,10 @@ github.com/inconshreveable/mousetrap
 # github.com/pmezard/go-difflib v1.0.0
 ## explicit
 github.com/pmezard/go-difflib/difflib
-# github.com/sixafter/nanoid v1.49.0
+# github.com/sixafter/aes-ctr-drbg v1.8.0
+## explicit; go 1.25
+github.com/sixafter/aes-ctr-drbg
+# github.com/sixafter/nanoid v1.50.0
 ## explicit; go 1.25
 github.com/sixafter/nanoid
 # github.com/sixafter/prng-chacha v1.4.0


### PR DESCRIPTION
This PR upgrades to [sixafter/nanoid@v1.50.0](https://github.com/sixafter/nanoid/releases/tag/v1.50.0).  Please note the [new `WithAutoRandReader`](https://github.com/sixafter/nanoid/blob/main/CHANGELOG/CHANGELOG-1.x.md#1500---2025-09-10) feature that automatically selects a FIPS 140 compliant reader if `GODEBUG=fips140=on` is set.